### PR TITLE
Added new "I" parameter to M106

### DIFF
--- a/GCodes.h
+++ b/GCodes.h
@@ -223,6 +223,7 @@ class GCodes
     bool axisIsHomed[3];	// these record which of the axes have been homed
     float fanMaxPwm;		// the M106 S value that represents 100% fan speed
     bool waitingForMoveToComplete;
+    bool coolingInverted;
 };
 
 //*****************************************************************************************************


### PR DESCRIPTION
I've added a new "I" parameter to M106, so passing a non-zero value will invert the cooling fan PWM value. This is required when using a 4-pin PWM fan.
