### PR TITLE
Fixed G31 for Z endstop switch

### DIFF
--- a/Platform.cpp
+++ b/Platform.cpp
@@ -124,6 +124,8 @@ void Platform::Init()
 		nvData.gateWay = GATE_WAY;
 
 		nvData.zProbeType = 0;	// Default is to use the switch
+		nvData.switchZProbeParameters.Init();
+		nvData.switchZProbeParameters.height = 0.0; // Assume the nozzle is at Z=0 when the switch is triggered
 		nvData.irZProbeParameters.Init();
 		nvData.ultrasonicZProbeParameters.Init();
 
@@ -360,8 +362,11 @@ int Platform::GetZProbeType() const
 
 float Platform::ZProbeStopHeight() const
 {
+
 	switch (nvData.zProbeType)
 	{
+	case 0:
+		return nvData.switchZProbeParameters.GetStopHeight(GetTemperature(0));
 	case 1:
 	case 2:
 		return nvData.irZProbeParameters.GetStopHeight(GetTemperature(0));
@@ -387,6 +392,9 @@ bool Platform::GetZProbeParameters(struct ZProbeParameters& params) const
 {
 	switch (nvData.zProbeType)
 	{
+	case 0:
+		params = nvData.switchZProbeParameters;
+		return true;
 	case 1:
 	case 2:
 		params = nvData.irZProbeParameters;
@@ -403,6 +411,12 @@ bool Platform::SetZProbeParameters(const struct ZProbeParameters& params)
 {
 	switch (nvData.zProbeType)
 	{
+	case 0:
+		if (nvData.switchZProbeParameters != params)
+		{
+			nvData.switchZProbeParameters = params;
+			WriteNvData();
+		}
 	case 1:
 	case 2:
 		if (nvData.irZProbeParameters != params)

--- a/Platform.h
+++ b/Platform.h
@@ -613,8 +613,9 @@ private:
 
 	  // The remaining data could alternatively be saved to SD card.
 	  // Note however that if we save them as G codes, we need to provide a way of saving IR and ultrasonic G31 parameters separately.
+	  ZProbeParameters switchZProbeParameters;		// Z probe values for the endstop switch
 	  ZProbeParameters irZProbeParameters;			// Z probe values for the IR sensor
-	  ZProbeParameters ultrasonicZProbeParameters;	// Z probe values for the IR sensor
+	  ZProbeParameters ultrasonicZProbeParameters;	// Z probe values for the ultrasonic sensor
 	  int zProbeType;								// the type of Z probe we are currently using
 	  PidParameters pidParams[HEATERS];
 	  byte ipAddress[4];


### PR DESCRIPTION
When using a Z endstop switch, one could not specify a switch offset by using G31 Z. This commit fixes this issue - tested and working.
