### PR TITLE
Incorrect strncat() call in ethernet_configure_interface()

### DIFF
--- a/ArduinoCorePatches/sam/cores/arduino/USB/USBCore.cpp
+++ b/ArduinoCorePatches/sam/cores/arduino/USB/USBCore.cpp
@@ -341,7 +341,7 @@ static bool USBD_SendConfiguration(int maxlen)
 	//TRACE_CORE(printf("=> USBD_SendConfiguration sizeof=%d\r\n", sizeof(ConfigDescriptor));)
 
 _Pragma("pack(1)")
-     ConfigDescriptor config = D_CONFIG((uint16_t)(_cmark + sizeof(ConfigDescriptor)),(uint8_t)interfaces);
+	ConfigDescriptor config = D_CONFIG((uint16_t)(_cmark + sizeof(ConfigDescriptor)),(uint8_t)interfaces);
 _Pragma("pack()")
 	//TRACE_CORE(printf("=> USBD_SendConfiguration clen=%d\r\n", config.clen);)
 
@@ -364,7 +364,7 @@ static bool USBD_SendOtherConfiguration(int maxlen)
 	//TRACE_CORE(printf("=> USBD_SendConfiguration sizeof=%d\r\n", sizeof(ConfigDescriptor));)
 
 _Pragma("pack(1)")
-     ConfigDescriptor config = D_OTHERCONFIG((uint16_t)(_cmark + sizeof(ConfigDescriptor)),(uint8_t)interfaces);
+	ConfigDescriptor config = D_OTHERCONFIG((uint16_t)(_cmark + sizeof(ConfigDescriptor)),(uint8_t)interfaces);
 _Pragma("pack()")
 	//TRACE_CORE(printf("=> USBD_SendConfiguration clen=%d\r\n", config.clen);)
 

--- a/ArduinoCorePatches/sam/cores/arduino/USB/USBCore.cpp
+++ b/ArduinoCorePatches/sam/cores/arduino/USB/USBCore.cpp
@@ -341,7 +341,7 @@ static bool USBD_SendConfiguration(int maxlen)
 	//TRACE_CORE(printf("=> USBD_SendConfiguration sizeof=%d\r\n", sizeof(ConfigDescriptor));)
 
 _Pragma("pack(1)")
-	ConfigDescriptor config = D_CONFIG(_cmark + sizeof(ConfigDescriptor),interfaces);
+     ConfigDescriptor config = D_CONFIG((uint16_t)(_cmark + sizeof(ConfigDescriptor)),(uint8_t)interfaces);
 _Pragma("pack()")
 	//TRACE_CORE(printf("=> USBD_SendConfiguration clen=%d\r\n", config.clen);)
 
@@ -364,7 +364,7 @@ static bool USBD_SendOtherConfiguration(int maxlen)
 	//TRACE_CORE(printf("=> USBD_SendConfiguration sizeof=%d\r\n", sizeof(ConfigDescriptor));)
 
 _Pragma("pack(1)")
-	ConfigDescriptor config = D_OTHERCONFIG(_cmark + sizeof(ConfigDescriptor),interfaces);
+     ConfigDescriptor config = D_OTHERCONFIG((uint16_t)(_cmark + sizeof(ConfigDescriptor)),(uint8_t)interfaces);
 _Pragma("pack()")
 	//TRACE_CORE(printf("=> USBD_SendConfiguration clen=%d\r\n", config.clen);)
 

--- a/GCodes.h
+++ b/GCodes.h
@@ -170,7 +170,7 @@ class GCodes
     FileStore* fileBeingWritten;				// A file to write G Codes (or sometimes HTML) in
     FileStore* configFile;						// A file containing a macro
     bool doingCannedCycleFile;					// Are we executing a macro file?
-    char* eofString;							// What's at the end of an HTML file?
+    const char* eofString;							// What's at the end of an HTML file?
     uint8_t eofStringCounter;					// Check the...
     uint8_t eofStringLength;					// ... EoF string as we read.
     int8_t selectedHead;						// Which extruder is in use

--- a/Libraries/Lwip/lwip/src/sam/netif/ethernetif.c
+++ b/Libraries/Lwip/lwip/src/sam/netif/ethernetif.c
@@ -362,7 +362,9 @@ static struct pbuf *low_level_input(struct netif *netif)
 
 	/* Obtain the size of the packet and put it into the "len"
 	 * variable. */
-	uc_rc = emac_dev_read(&gs_emac_dev, pc_buf, sizeof(pc_buf), &ul_frmlen);
+	// Note 4th parameter should be uint32_t* (unsigned long int*)
+	// but we're passing an unsigned int*.  Promotion is okay.
+	uc_rc = emac_dev_read(&gs_emac_dev, pc_buf, sizeof(pc_buf), (uint32_t*)&ul_frmlen);
 	if (uc_rc != EMAC_OK) {
 		return NULL;
 	}

--- a/Platform.cpp
+++ b/Platform.cpp
@@ -814,7 +814,7 @@ void Platform::PrintMemoryUsage()
 	Message(HOST_MESSAGE, scratchString);
 }
 
-void Platform::ClassReport(char* className, float &lastTime)
+void Platform::ClassReport(const char* className, float &lastTime)
 {
 	if (!reprap.Debug())
 		return;

--- a/Platform.h
+++ b/Platform.h
@@ -53,6 +53,14 @@ Licence: GPL
 #include "SD_HSMCI.h"
 #include "MCP4461.h"
 
+// Prevent conflict warnings; override defs from compiler.h
+#ifdef ENABLE
+#undef ENABLE
+#endif
+#ifdef DISABLE
+#undef DISABLE
+#endif
+
 /**************************************************************************************************/
 
 // Some numbers...
@@ -526,7 +534,7 @@ public:
   void SetEmulating(Compatibility c);
   void Diagnostics();
   void PrintMemoryUsage();  // Print memory stats for debugging
-  void ClassReport(char* className, float &lastTime);  // Called on return to check everything's live.
+  void ClassReport(const char* className, float &lastTime);  // Called on return to check everything's live.
   void RecordError(ErrorCode ec) { errorCodeBits |= ec; }
   void SetDebug(int d);
   void SoftwareReset(uint16_t reason);
@@ -721,11 +729,11 @@ private:
   MassStorage* massStorage;
   FileStore* files[MAX_FILES];
   bool fileStructureInitialised;
-  char* webDir;
-  char* gcodeDir;
-  char* sysDir;
-  char* tempDir;
-  char* configFile;
+  const char* webDir;
+  const char* gcodeDir;
+  const char* sysDir;
+  const char* tempDir;
+  const char* configFile;
   
 // Data used by the tick interrupt handler
 

--- a/network/ethernet_sam.c
+++ b/network/ethernet_sam.c
@@ -151,7 +151,7 @@ static void timers_update(void)
 
 // Added by AB.
 
-static void ethernet_configure_interface(unsigned char ipAddress[], unsigned char netMask[], unsigned char gateWay[])
+static void ethernet_configure_interface(const unsigned char ipAddress[], const unsigned char netMask[], const unsigned char gateWay[])
 {
 	struct ip_addr x_ip_addr, x_net_mask, x_gateway;
 	extern err_t ethernetif_init(struct netif *netif);
@@ -235,7 +235,7 @@ void status_callback(struct netif *netif)
 	{
 		RepRapNetworkMessage("Network up, IP=");
 		ipaddr_ntoa_r(&(netif->ip_addr), c_mess, sizeof(c_mess));
-		strncat(c_mess, sizeof(c_mess) - 1, "\n");
+		strncat(c_mess, "\n", sizeof(c_mess) - 1);
 		RepRapNetworkMessage(c_mess);
 		netif->flags |= NETIF_FLAG_LINK_UP;
 	}

--- a/network/lwip_test.h
+++ b/network/lwip_test.h
@@ -14,7 +14,10 @@
 #include "ethernet_sam.h"
 #include "timer_mgt_sam.h"
 #include <stdarg.h>
+
+#ifdef printf
 #undef printf
+#endif
 
 //end of add your includes here
 #ifdef __cplusplus
@@ -27,7 +30,7 @@ void setup();
 #endif
 
 //add your function definitions for the project lwip_test here
-void printf(char *fmt, ... );
+int printf(const char *fmt, ... );
 
 //Do not add code below this line
 #endif /* lwip_test_H_ */


### PR DESCRIPTION
The second and third call arguments are interchanged and thus some odd number of bytes starting at address 0x13 [sizeof(c_mess)-1 = 19] are being concatenated to c_mess and not the expected \n.  (The address of the "\n" string on the stack is being used as the length of the string buffer I believe.  Seems like this routine will scribble on the stack starting at the location of c_mess on the stack.

Anyhow, I noticed this as I was making changes to my repo to address the compiler warnings.  This was one of the compiler warnings.  (I just wish that the Arduino libraries weren't riddled with warnings.)