### PR TITLE
6 extruder platform mods

### DIFF
--- a/Libraries/SamNonDuePin/SamNonDuePin.cpp
+++ b/Libraries/SamNonDuePin/SamNonDuePin.cpp
@@ -37,15 +37,25 @@ extern const PinDescription nonDuePinDescription[]=
   { PIOC, PIO_PC8B_PWML3,   ID_PIOC, PIO_PERIPH_B, PIO_DEFAULT, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM),	NO_ADC, NO_ADC, PWM_CH3,    NOT_ON_TIMER }, // PWM X5
   { PIOC, PIO_PC2B_PWML0,   ID_PIOC, PIO_PERIPH_B, PIO_DEFAULT, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM),	NO_ADC, NO_ADC, PWM_CH0,    NOT_ON_TIMER }, // PWM X6
   { PIOC, PIO_PC6B_PWML2,   ID_PIOC, PIO_PERIPH_B, PIO_DEFAULT, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM),	NO_ADC, NO_ADC, PWM_CH2,    NOT_ON_TIMER }, // PWM X7
-  { PIOC, PIO_PC20,			ID_PIOC, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PWM X8
-  // 9 .. 14
+  { PIOC, PIO_PC20,			ID_PIOC, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X8
+  { PIOD, PIO_PD9,			ID_PIOD, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X9
+  //10-14
+  { PIOC, PIO_PC29,			ID_PIOC, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X10
+  { PIOC, PIO_PC30,			ID_PIOC, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X11
+  { PIOC, PIO_PC10,			ID_PIOC, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X12
+  { PIOC, PIO_PC28,			ID_PIOC, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X13
+  { PIOB, PIO_PB22,			ID_PIOB, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X14
+  { PIOB, PIO_PB23,			ID_PIOB, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X15
+  { PIOB, PIO_PB24,			ID_PIOB, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN X16
+  { PIOC, PIO_PC4B_PWML1,   ID_PIOC, PIO_PERIPH_B, PIO_DEFAULT, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM),	NO_ADC, NO_ADC, PWM_CH1,    NOT_ON_TIMER }, // PWM X17
+  // 18-23 - HSMCI
   { PIOA, PIO_PA20A_MCCDA,  ID_PIOA, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,   				NO_ADC, NO_ADC, NOT_ON_PWM,	NOT_ON_TIMER }, // PIN_HSMCI_MCCDA_GPIO
   { PIOA, PIO_PA19A_MCCK,	ID_PIOA, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN_HSMCI_MCCK_GPIO
   { PIOA, PIO_PA21A_MCDA0,  ID_PIOA, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN_HSMCI_MCDA0_GPIO
   { PIOA, PIO_PA22A_MCDA1,  ID_PIOA, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN_HSMCI_MCDA1_GPIO
   { PIOA, PIO_PA23A_MCDA2,  ID_PIOA, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN_HSMCI_MCDA2_GPIO
   { PIOA, PIO_PA24A_MCDA3,  ID_PIOA, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // PIN_HSMCI_MCDA3_GPIO
-  // 15 .. 24 - ETHERNET MAC
+  // 24-33 - ETHERNET MAC
   { PIOB, PIO_PB0A_ETXCK,   ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // ETXCK
   { PIOB, PIO_PB1A_ETXEN,   ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // ETXEN
   { PIOB, PIO_PB2A_ETX0,	ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // ETX0
@@ -55,12 +65,11 @@ extern const PinDescription nonDuePinDescription[]=
   { PIOB, PIO_PB6A_ERX1,	ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // ERX1
   { PIOB, PIO_PB7A_ERXER,   ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // ERXER
   { PIOB, PIO_PB8A_EMDC,	ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // EMDC
-  { PIOB, PIO_PB9A_EMDIO,   ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }, // EMDIO
-  // 25
-  { PIOC, PIO_PC10,			ID_PIOC, PIO_OUTPUT_0, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }  // PIN X25
+  { PIOB, PIO_PB9A_EMDIO,   ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, PIN_ATTR_DIGITAL,					NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER } // EMDIO
+
 };
 
-const uint32_t MaxPinNumber = X25;
+const uint32_t MaxPinNumber = X17;
 
 /*
 pinModeNonDue
@@ -262,61 +271,61 @@ void analogWriteNonDue(uint32_t ulPin, uint32_t ulValue, bool fastPwm)
 //initialise HSMCI pins
 void hsmciPinsinit()
 {
-  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCCDA_GPIO].pPort,nonDuePinDescription[PIN_HSMCI_MCCDA_GPIO].ulPinType,nonDuePinDescription[PIN_HSMCI_MCCDA_GPIO].ulPin,nonDuePinDescription[PIN_HSMCI_MCCDA_GPIO].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCCK_GPIO].pPort,nonDuePinDescription[PIN_HSMCI_MCCK_GPIO].ulPinType,nonDuePinDescription[PIN_HSMCI_MCCK_GPIO].ulPin,nonDuePinDescription[PIN_HSMCI_MCCK_GPIO].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCDA0_GPIO].pPort,nonDuePinDescription[PIN_HSMCI_MCDA0_GPIO].ulPinType,nonDuePinDescription[PIN_HSMCI_MCDA0_GPIO].ulPin,nonDuePinDescription[PIN_HSMCI_MCDA0_GPIO].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCDA1_GPIO].pPort,nonDuePinDescription[PIN_HSMCI_MCDA1_GPIO].ulPinType,nonDuePinDescription[PIN_HSMCI_MCDA1_GPIO].ulPin,nonDuePinDescription[PIN_HSMCI_MCDA1_GPIO].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCDA2_GPIO].pPort,nonDuePinDescription[PIN_HSMCI_MCDA2_GPIO].ulPinType,nonDuePinDescription[PIN_HSMCI_MCDA2_GPIO].ulPin,nonDuePinDescription[PIN_HSMCI_MCDA2_GPIO].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCDA3_GPIO].pPort,nonDuePinDescription[PIN_HSMCI_MCDA3_GPIO].ulPinType,nonDuePinDescription[PIN_HSMCI_MCDA3_GPIO].ulPin,nonDuePinDescription[PIN_HSMCI_MCDA3_GPIO].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCCDA_GPIO - X0].pPort,nonDuePinDescription[PIN_HSMCI_MCCDA_GPIO - X0].ulPinType,nonDuePinDescription[PIN_HSMCI_MCCDA_GPIO - X0].ulPin,nonDuePinDescription[PIN_HSMCI_MCCDA_GPIO - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCCK_GPIO - X0].pPort,nonDuePinDescription[PIN_HSMCI_MCCK_GPIO - X0].ulPinType,nonDuePinDescription[PIN_HSMCI_MCCK_GPIO - X0].ulPin,nonDuePinDescription[PIN_HSMCI_MCCK_GPIO - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCDA0_GPIO - X0].pPort,nonDuePinDescription[PIN_HSMCI_MCDA0_GPIO - X0].ulPinType,nonDuePinDescription[PIN_HSMCI_MCDA0_GPIO - X0].ulPin,nonDuePinDescription[PIN_HSMCI_MCDA0_GPIO - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCDA1_GPIO - X0].pPort,nonDuePinDescription[PIN_HSMCI_MCDA1_GPIO - X0].ulPinType,nonDuePinDescription[PIN_HSMCI_MCDA1_GPIO - X0].ulPin,nonDuePinDescription[PIN_HSMCI_MCDA1_GPIO - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCDA2_GPIO - X0].pPort,nonDuePinDescription[PIN_HSMCI_MCDA2_GPIO - X0].ulPinType,nonDuePinDescription[PIN_HSMCI_MCDA2_GPIO - X0].ulPin,nonDuePinDescription[PIN_HSMCI_MCDA2_GPIO - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_HSMCI_MCDA3_GPIO - X0].pPort,nonDuePinDescription[PIN_HSMCI_MCDA3_GPIO - X0].ulPinType,nonDuePinDescription[PIN_HSMCI_MCDA3_GPIO - X0].ulPin,nonDuePinDescription[PIN_HSMCI_MCDA3_GPIO - X0].ulPinConfiguration);
   //set pullups (not on clock!)
-  digitalWriteNonDue(PIN_HSMCI_MCCDA_GPIO+X0, HIGH);
-  digitalWriteNonDue(PIN_HSMCI_MCDA0_GPIO+X0, HIGH);
-  digitalWriteNonDue(PIN_HSMCI_MCDA1_GPIO+X0, HIGH);
-  digitalWriteNonDue(PIN_HSMCI_MCDA2_GPIO+X0, HIGH);
-  digitalWriteNonDue(PIN_HSMCI_MCDA3_GPIO+X0, HIGH);
+  digitalWriteNonDue(PIN_HSMCI_MCCDA_GPIO - X0, HIGH);
+  digitalWriteNonDue(PIN_HSMCI_MCDA0_GPIO - X0, HIGH);
+  digitalWriteNonDue(PIN_HSMCI_MCDA1_GPIO - X0, HIGH);
+  digitalWriteNonDue(PIN_HSMCI_MCDA2_GPIO - X0, HIGH);
+  digitalWriteNonDue(PIN_HSMCI_MCDA3_GPIO - X0, HIGH);
 }
 
 //initialise ethernet pins
 void ethPinsInit()
 {
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_EREFCK].pPort,
-			  nonDuePinDescription[PIN_EMAC_EREFCK].ulPinType,
-			  nonDuePinDescription[PIN_EMAC_EREFCK].ulPin,
-			  nonDuePinDescription[PIN_EMAC_EREFCK].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_ETXEN].pPort,
-		  nonDuePinDescription[PIN_EMAC_ETXEN].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_ETXEN].ulPin,
-		  nonDuePinDescription[PIN_EMAC_ETXEN].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_ETX0].pPort,
-		  nonDuePinDescription[PIN_EMAC_ETX0].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_ETX0].ulPin,
-		  nonDuePinDescription[PIN_EMAC_ETX0].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_ETX1].pPort,
-		  nonDuePinDescription[PIN_EMAC_ETX1].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_ETX1].ulPin,
-		  nonDuePinDescription[PIN_EMAC_ETX1].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_ECRSDV].pPort,
-		  nonDuePinDescription[PIN_EMAC_ECRSDV].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_ECRSDV].ulPin,
-		  nonDuePinDescription[PIN_EMAC_ECRSDV].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_ERX0].pPort,
-		  nonDuePinDescription[PIN_EMAC_ERX0].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_ERX0].ulPin,
-		  nonDuePinDescription[PIN_EMAC_ERX0].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_ERX1].pPort,
-		  nonDuePinDescription[PIN_EMAC_ERX1].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_ERX1].ulPin,
-		  nonDuePinDescription[PIN_EMAC_ERX1].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_ERXER].pPort,
-		  nonDuePinDescription[PIN_EMAC_ERXER].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_ERXER].ulPin,
-		  nonDuePinDescription[PIN_EMAC_ERXER].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_EMDC].pPort,
-		  nonDuePinDescription[PIN_EMAC_EMDC].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_EMDC].ulPin,
-		  nonDuePinDescription[PIN_EMAC_EMDC].ulPinConfiguration);
-  PIO_Configure(nonDuePinDescription[PIN_EMAC_EMDIO].pPort,
-		  nonDuePinDescription[PIN_EMAC_EMDIO].ulPinType,
-		  nonDuePinDescription[PIN_EMAC_EMDIO].ulPin,
-		  nonDuePinDescription[PIN_EMAC_EMDIO].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_EREFCK - X0].pPort,
+			  nonDuePinDescription[PIN_EMAC_EREFCK - X0].ulPinType,
+			  nonDuePinDescription[PIN_EMAC_EREFCK - X0].ulPin,
+			  nonDuePinDescription[PIN_EMAC_EREFCK - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_ETXEN - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_ETXEN - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_ETXEN - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_ETXEN - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_ETX0 - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_ETX0 - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_ETX0 - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_ETX0 - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_ETX1 - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_ETX1 - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_ETX1 - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_ETX1 - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_ECRSDV - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_ECRSDV - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_ECRSDV - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_ECRSDV - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_ERX0 - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_ERX0 - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_ERX0 - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_ERX0 - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_ERX1 - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_ERX1 - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_ERX1 - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_ERX1 - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_ERXER - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_ERXER - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_ERXER - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_ERXER - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_EMDC - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_EMDC - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_EMDC - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_EMDC - X0].ulPinConfiguration);
+  PIO_Configure(nonDuePinDescription[PIN_EMAC_EMDIO - X0].pPort,
+		  nonDuePinDescription[PIN_EMAC_EMDIO - X0].ulPinType,
+		  nonDuePinDescription[PIN_EMAC_EMDIO - X0].ulPin,
+		  nonDuePinDescription[PIN_EMAC_EMDIO - X0].ulPinConfiguration);
 }

--- a/Libraries/SamNonDuePin/SamNonDuePin.h
+++ b/Libraries/SamNonDuePin/SamNonDuePin.h
@@ -18,7 +18,7 @@
 
 /*
 Code from wiring-digital.c and wiring-analog.c from the arduino core.
-See undefined.cpp file for more info
+See SamNonDuePin.cpp file for more info
 */
 
 #ifndef SAM_NON_DUE_PIN_H
@@ -27,7 +27,7 @@ See undefined.cpp file for more info
 #include "Arduino.h"
 
 // Number of pins defined in PinDescription array
-#define PINS_C 26
+//#define PINS_C 28  //not used
 
 static const unsigned int pwmFastFrequency = 25000;		// fast PWM frequency for Intel spec PWM fans
 
@@ -35,36 +35,45 @@ static const unsigned int pwmFastFrequency = 25000;		// fast PWM frequency for I
 // Any pin numbers below X0 we assume are ordinary Due pin numbers
 // Note: these must all be <=127 because pin numbers are held in int8_t in some places.
 // There are 92 pins defined in the Arduino Due core as at version 1.5.4, so these must all be >=92
-static const uint8_t X0  = 100;
-static const uint8_t X1  = 101;
-static const uint8_t X2  = 102;
-static const uint8_t X3  = 103;
-static const uint8_t X4  = 104;
-static const uint8_t X5  = 105;
-static const uint8_t X6  = 106;
-static const uint8_t X7  = 107;
-static const uint8_t X8  = 108;
+// 2015-07-08 Tony@t3p3 Added the additional pins for the Duet 0.8.5, changed the mapping to start at 93 (>=92) and
+// finish at 126 (<=127).
+static const uint8_t X0  = 93;
+static const uint8_t X1  = 94;
+static const uint8_t X2  = 95;
+static const uint8_t X3  = 96;
+static const uint8_t X4  = 97;
+static const uint8_t X5  = 98;
+static const uint8_t X6  = 99;
+static const uint8_t X7  = 100;
+static const uint8_t X8  = 101;
+static const uint8_t X9  = 102;
+static const uint8_t X10  = 103;
+static const uint8_t X11  = 104;
+static const uint8_t X12  = 105; //probe
+static const uint8_t X13  = 106;
+static const uint8_t X14  = 107;
+static const uint8_t X15  = 108;
+static const uint8_t X16  = 109;
+static const uint8_t X17  = 110;
 //HSMCI
-static const uint8_t PIN_HSMCI_MCCDA_GPIO  = 9;
-static const uint8_t PIN_HSMCI_MCCK_GPIO  = 10;
-static const uint8_t PIN_HSMCI_MCDA0_GPIO  = 11;
-static const uint8_t PIN_HSMCI_MCDA1_GPIO  = 12;
-static const uint8_t PIN_HSMCI_MCDA2_GPIO  = 13;
-static const uint8_t PIN_HSMCI_MCDA3_GPIO  = 14;
+static const uint8_t PIN_HSMCI_MCCDA_GPIO  = 111;
+static const uint8_t PIN_HSMCI_MCCK_GPIO  = 112;
+static const uint8_t PIN_HSMCI_MCDA0_GPIO  = 113;
+static const uint8_t PIN_HSMCI_MCDA1_GPIO  = 114;
+static const uint8_t PIN_HSMCI_MCDA2_GPIO  = 115;
+static const uint8_t PIN_HSMCI_MCDA3_GPIO  = 116;
 //EMAC
-static const uint8_t PIN_EMAC_EREFCK_GPIO  = 15; //What is this one for?
-static const uint8_t PIN_EMAC_EREFCK  = 15;
-static const uint8_t PIN_EMAC_ETXEN  = 16;
-static const uint8_t PIN_EMAC_ETX0  = 17;
-static const uint8_t PIN_EMAC_ETX1  = 18;
-static const uint8_t PIN_EMAC_ECRSDV  = 19;
-static const uint8_t PIN_EMAC_ERX0  = 20;
-static const uint8_t PIN_EMAC_ERX1  = 21;
-static const uint8_t PIN_EMAC_ERXER  = 22;
-static const uint8_t PIN_EMAC_EMDC  = 23;
-static const uint8_t PIN_EMAC_EMDIO  = 24;
-//PROBE RIG
-static const uint8_t X25  = 125;
+static const uint8_t PIN_EMAC_EREFCK  = 117;
+static const uint8_t PIN_EMAC_ETXEN  = 118;
+static const uint8_t PIN_EMAC_ETX0  = 119;
+static const uint8_t PIN_EMAC_ETX1  = 120;
+static const uint8_t PIN_EMAC_ECRSDV  = 121;
+static const uint8_t PIN_EMAC_ERX0  = 122;
+static const uint8_t PIN_EMAC_ERX1  = 123;
+static const uint8_t PIN_EMAC_ERXER  = 124;
+static const uint8_t PIN_EMAC_EMDC  = 125;
+static const uint8_t PIN_EMAC_EMDIO  = 126;
+
 
 // struct used to hold the descriptions for the "non arduino" pins.
 // from the Arduino.h files

--- a/Platform.h
+++ b/Platform.h
@@ -64,9 +64,9 @@ Licence: GPL
 
 // The physical capabilities of the machine
 
-#define DRIVES 8 // The number of drives in the machine, including X, Y, and Z plus extruder drives
+#define DRIVES 9 // The number of drives in the machine, including X, Y, and Z plus extruder drives
 #define AXES 3 // The number of movement axes in the machine, usually just X, Y and Z. <= DRIVES
-#define HEATERS 6 // The number of heaters in the machine; 0 is the heated bed even if there isn't one.
+#define HEATERS 7 // The number of heaters in the machine; 0 is the heated bed even if there isn't one.
 
 // The numbers of entries in each array must correspond with the values of DRIVES,
 // AXES, or HEATERS. Set values to -1 to flag unavailability.
@@ -75,16 +75,16 @@ Licence: GPL
 
 // DRIVES
 
-#define STEP_PINS {14, 25, 5, X2, 41, 39, X4, 49}
-#define DIRECTION_PINS {15, 26, 4, X3, 35, 53, 51, 48}
+#define STEP_PINS {14, 25, 5, X2, 41, 39, X4, 49, X10}
+#define DIRECTION_PINS {15, 26, 4, X3, 35, 53, 51, 48, X11}
 #define FORWARDS true // What to send to go...
 #define BACKWARDS (!FORWARDS) // ...in each direction
-#define DIRECTIONS {BACKWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS} // What each axis needs to make it go forwards - defaults
-#define ENABLE_PINS {29, 27, X1, X0, 37, X8, 50, 47}
+#define DIRECTIONS {BACKWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS, FORWARDS} // What each axis needs to make it go forwards - defaults
+#define ENABLE_PINS {29, 27, X1, X0, 37, X8, 50, 47, X13}
 #define ENABLE_DRIVE false // What to send to enable...
 #define DISABLE_DRIVE true // ...and disable a drive
-#define DISABLE_DRIVES {false, false, true, false, false, false, false, false} // Set true to disable a drive when it becomes idle
-#define END_STOP_PINS {11, 28, 60, 31, 24, 46, 45, 44} //E Stops not currently used
+#define DISABLE_DRIVES {false, false, true, false, false, false, false, false, false} // Set true to disable a drive when it becomes idle
+#define END_STOP_PINS {11, 28, 60, 31, 24, 46, 45, 44, X9} //E Stops not currently used
 // Indices for motor current digipots (if any)
 // first 4 are for digipot 1,(on duet)
 // second 4 for digipot 2(on expansion board)
@@ -101,10 +101,10 @@ Licence: GPL
 #define Z_PROBE_AXES {true, false, true}		// Axes for which the Z-probe is normally used
 const unsigned int numZProbeReadingsAveraged = 8;	// we average this number of readings with IR on, and the same number with IR off
 
-#define MAX_FEEDRATES {100.0, 100.0, 3.0, 20.0, 20.0, 20.0, 20.0, 20.0} // mm/sec
-#define ACCELERATIONS {500.0, 500.0, 20.0, 250.0, 250.0, 250.0, 250.0, 250.0} // mm/sec^2
-#define DRIVE_STEPS_PER_UNIT {87.4890, 87.4890, 4000.0, 420.0, 420.0, 420.0, 420.0, 420.0}
-#define INSTANT_DVS {30.0, 30.0, 0.2, 2.0, 2.0, 2.0, 2.0, 2.0} // (mm/sec)
+#define MAX_FEEDRATES {100.0, 100.0, 3.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0} // mm/sec
+#define ACCELERATIONS {500.0, 500.0, 20.0, 250.0, 250.0, 250.0, 250.0, 250.0, 250.0} // mm/sec^2
+#define DRIVE_STEPS_PER_UNIT {87.4890, 87.4890, 4000.0, 420.0, 420.0, 420.0, 420.0, 420.0, 420.0}
+#define INSTANT_DVS {30.0, 30.0, 0.2, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0} // (mm/sec)
 
 // AXES
 
@@ -120,13 +120,13 @@ const size_t A_AXIS = 0, B_AXIS = 1, C_AXIS = 2;	// The indices of the 3 tower m
 
 // HEATERS - The bed is assumed to be the at index 0
 
-#define TEMP_SENSE_PINS {5, 4, 0, 7, 8, 9} // Analogue pin numbers
-#define HEAT_ON_PINS {6, X5, X7, 7, 8, 9} //pin D38 is PWM capable but not an Arduino PWM pin
+#define TEMP_SENSE_PINS {5, 4, 0, 7, 8, 9, 11} // Analogue pin numbers
+#define HEAT_ON_PINS {6, X5, X7, 7, 8, 9, X17} //pin D38 is PWM capable but not an Arduino PWM pin
 // Bed thermistor: http://uk.farnell.com/epcos/b57863s103f040/sensor-miniature-ntc-10k/dp/1299930?Ntt=129-9930
 // Hot end thermistor: http://www.digikey.co.uk/product-search/en?x=20&y=11&KeyWords=480-3137-ND
-const float defaultThermistorBetas[HEATERS] = {3988.0, 4138.0, 4138.0, 4138.0, 4138.0, 4138.0}; // Bed thermistor: B57861S104F40; Extruder thermistor: RS 198-961
-const float defaultThermistorSeriesRs[HEATERS] = {1000, 1000, 1000, 1000, 1000, 1000}; // Ohms in series with the thermistors
-const float defaultThermistor25RS[HEATERS] = {10000.0, 100000.0, 100000.0, 100000.0, 100000.0, 100000.0}; // Thermistor ohms at 25 C = 298.15 K
+const float defaultThermistorBetas[HEATERS] = {3988.0, 4138.0, 4138.0, 4138.0, 4138.0, 4138.0, 4138.0}; // Bed thermistor: B57861S104F40; Extruder thermistor: RS 198-961
+const float defaultThermistorSeriesRs[HEATERS] = {1000, 1000, 1000, 1000, 1000, 1000, 1000}; // Ohms in series with the thermistors
+const float defaultThermistor25RS[HEATERS] = {10000.0, 100000.0, 100000.0, 100000.0, 100000.0, 100000.0, 100000.0}; // Thermistor ohms at 25 C = 298.15 K
 
 // Note on hot end PID parameters:
 // The system is highly nonlinear because the heater power is limited to a maximum value and cannot go negative.
@@ -153,17 +153,17 @@ const float defaultThermistor25RS[HEATERS] = {10000.0, 100000.0, 100000.0, 10000
 // This allows us to switch between PID and bang-bang using the M301 and M304 commands.
 
 // We use method 2 (see above)
-const float defaultPidKis[HEATERS] = {5.0, 0.1, 0.1, 0.1, 0.1, 0.1}; 			// Integral PID constants
-const float defaultPidKds[HEATERS] = {500.0, 100.0, 100.0, 100.0, 100.0, 100.0}; // Derivative PID constants
-const float defaultPidKps[HEATERS] = {-1.0, 10.0, 10.0, 10.0, 10.0, 10.0};		// Proportional PID constants, negative values indicate use bang-bang instead of PID
-const float defaultPidKts[HEATERS] = {2.7, 0.4, 0.4, 0.4, 0.4, 0.4};			// approximate PWM value needed to maintain temperature, per degC above room temperature
-const float defaultPidKss[HEATERS] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};			// PWM scaling factor, to allow for variation in heater power and supply voltage
-const float defaultFullBands[HEATERS] = {5.0, 30.0, 30.0, 30.0, 30.0, 30.0};	// errors larger than this cause heater to be on or off
-const float defaultPidMins[HEATERS] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};			// minimum value of I-term
-const float defaultPidMaxes[HEATERS] = {255, 180, 180, 180, 180, 180};			// maximum value of I-term, must be high enough to reach 245C for ABS printing
+const float defaultPidKis[HEATERS] = {5.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1}; 			// Integral PID constants
+const float defaultPidKds[HEATERS] = {500.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0}; // Derivative PID constants
+const float defaultPidKps[HEATERS] = {-1.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0};		// Proportional PID constants, negative values indicate use bang-bang instead of PID
+const float defaultPidKts[HEATERS] = {2.7, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4};			// approximate PWM value needed to maintain temperature, per degC above room temperature
+const float defaultPidKss[HEATERS] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};			// PWM scaling factor, to allow for variation in heater power and supply voltage
+const float defaultFullBands[HEATERS] = {5.0, 30.0, 30.0, 30.0, 30.0, 30.0, 30.0};	// errors larger than this cause heater to be on or off
+const float defaultPidMins[HEATERS] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};			// minimum value of I-term
+const float defaultPidMaxes[HEATERS] = {255, 180, 180, 180, 180, 180, 180};			// maximum value of I-term, must be high enough to reach 245C for ABS printing
 
-#define STANDBY_TEMPERATURES {ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO} // We specify one for the bed, though it's not needed
-#define ACTIVE_TEMPERATURES {ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO}
+#define STANDBY_TEMPERATURES {ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO} // We specify one for the bed, though it's not needed
+#define ACTIVE_TEMPERATURES {ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO, ABS_ZERO}
 #define COOLING_FAN_PIN X6 														// pin D34 is PWM capable but not an Arduino PWM pin - use X6 instead
 #define COOLING_FAN_RPM_PIN 36													// pin PC4
 #define COOLING_FAN_RPM_SAMPLE_TIME	2.0											// Time to wait before resetting the internal fan RPM stats

--- a/Platform.h
+++ b/Platform.h
@@ -97,7 +97,7 @@ Licence: GPL
 #define Z_PROBE_STOP_HEIGHT (0.7) // mm
 #define Z_PROBE_PIN (10) 						// Analogue pin number
 #define Z_PROBE_MOD_PIN (52)					// Digital pin number to turn the IR LED on (high) or off (low)
-#define Z_PROBE_MOD_PIN07 (X25)					// Digital pin number to turn the IR LED on (high) or off (low) Duet V0.7 onwards
+#define Z_PROBE_MOD_PIN07 (X12)					// Digital pin number to turn the IR LED on (high) or off (low) Duet V0.7 onwards
 #define Z_PROBE_AXES {true, false, true}		// Axes for which the Z-probe is normally used
 const unsigned int numZProbeReadingsAveraged = 8;	// we average this number of readings with IR on, and the same number with IR off
 


### PR DESCRIPTION
This increases the number of drives from 8 to 9, the number of heaters from 6 to 7, and uses the new SamNonDuePin pin allocations to access the additional pins where required.

Includes and requires the changes to the SamNonDuePin library in PR https://github.com/dc42/RepRapFirmware/pull/11
