### PR TITLE
Stop json requests from caching in IE

### DIFF
--- a/Webserver.cpp
+++ b/Webserver.cpp
@@ -808,6 +808,9 @@ void Webserver::HttpInterpreter::SendJsonResponse(const char* command)
 	}
 
 	transaction->Write("HTTP/1.1 200 OK\n");
+	transaction->Write("Cache-Control: no-cache, no-store, must-revalidate\n");
+	transaction->Write("Pragma: no-cache\n");
+	transaction->Write("Expires: 0\n");
 	transaction->Write("Content-Type: application/json\n");
 	transaction->Printf("Content-Length: %u\n", (jsonResponse != nullptr) ? jsonResponse->Length() : 0);
 	transaction->Printf("Connection: %s\n\n", keepOpen ? "keep-alive" : "close");

--- a/Webserver.cpp
+++ b/Webserver.cpp
@@ -703,6 +703,9 @@ void Webserver::HttpInterpreter::SendGCodeReply(NetworkTransaction *transaction)
 {
 	// Send G-Code reply as plain text to the client
 	transaction->Write("HTTP/1.1 200 OK\n");
+	transaction->Write("Cache-Control: no-cache, no-store, must-revalidate\n");
+	transaction->Write("Pragma: no-cache\n");
+	transaction->Write("Expires: 0\n");
 	transaction->Write("Content-Type: text/plain\n");
 	transaction->Printf("Content-Length: %u\n", (gcodeReply != nullptr) ? gcodeReply->Length() : 0);
 	transaction->Write("Connection: close\n\n");


### PR DESCRIPTION
Web frontend doesn't work in IE because it caches repeated requests to
the same URL.  This change adds headers to json responses which will
prevent IE from caching.