### PR TITLE
Grid leveling bugfixes #2

### DIFF
--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -620,6 +620,7 @@ void GCodes::Spin()
 					{
 						reply.printf("%u points probed, mean error %.3f, deviation %.3f\n", numPointsProbed, mean, deviation);
 						error = SaveHeightMap(gb, reply);
+						reprap.GetMove()->AccessBedProbeGrid().ExtrapolateMissing();
 						reprap.GetMove()->AccessBedProbeGrid().UseHeightMap(true);
 					}
 					else

--- a/src/Movement/Grid.h
+++ b/src/Movement/Grid.h
@@ -81,6 +81,8 @@ public:
 
 	unsigned int GetStatistics(float& mean, float& deviation) const; // Return number of points probed, mean and RMS deviation
 
+	void ExtrapolateMissing();										//extrapolate missing points to ensure consistency
+
 private:
 	static const char *HeightMapComment;							// The start of the comment we write at the start of the height map file
 
@@ -92,12 +94,7 @@ private:
 	uint32_t GetMapIndex(uint32_t xIndex, uint32_t yIndex) const { return (yIndex * def.NumXpoints()) + xIndex; }
 	bool IsHeightSet(uint32_t index) const { return (gridHeightSet[index/32] & (1 << (index & 31))) != 0; }
 
-	float GetHeightError(uint32_t xIndex, uint32_t yIndex) const;
-	float InterpolateX(uint32_t xIndex, uint32_t yIndex, float xFrac) const;
-	float InterpolateY(uint32_t xIndex, uint32_t yIndex, float yFrac) const;
 	float InterpolateXY(uint32_t xIndex, uint32_t yIndex, float xFrac, float yFrac) const;
-	float Interpolate2(uint32_t index1, uint32_t index2, float frac) const;
-	float InterpolateCorner(uint32_t cornerIndex, uint32_t indexX, uint32_t indexY, float xFrac, float yFrac) const;
 };
 
 #endif /* SRC_MOVEMENT_GRID_H_ */


### PR DESCRIPTION
There was one issue remaining with the grid leveling: points which could not be probed will be clamped down to 0 for the heightmap interpolation. A user of the grid leveling could avoid this problem by setting the leveling area settings so that all points will be probed. But this is non-obvious for a user and also leaves another problem: the area which can't be probed will be now clamped to the last measured one.

Taking into account that the z-sensor might be far away from the nozzle (on a BigBox it's 65mm) and the fact that one can't set the probing spacing separately for X and Y the resulting unmeasured border might be quite large.

My solution to this is: extrapolating the missing unprobed points by using linear least squares in 3d-space and derive a plane from it. The HeightMap::ExtrapolateMissing() function will need at least 3 valid points and in this corner case it will create the exact plane through these.

Now that I have always a valid and complete grid I can remove the complexity of GetInterpolatedHeightError since it has to handle only one case, outside values can just be clamped to the rectangle.

An example is this sparsely measured grid:
xmin,xmax,ymin,ymax,radius,spacing,xnum,ynum
0,300,0,200,-1.00,100.00,4,3
		0, 1, 0.01, 0
		0, 1, 0.01, 0
		0, 1, 0.01, 0

which would have resulted in this:
![a](https://cloud.githubusercontent.com/assets/3427525/23665665/6a034cc4-0359-11e7-9bed-f6d30f49bf49.png)
will now look like this:
![b](https://cloud.githubusercontent.com/assets/3427525/23665680/730562f8-0359-11e7-96bf-aff2998b0805.png)

Or the example from yesterday with the missing right border:
![bed_5](https://cloud.githubusercontent.com/assets/3427525/23665732/8effcf84-0359-11e7-955b-47b74d9868ac.png)
will just continue in the general slope direction:
