### PR TITLE
Fixed setup/config of CoreXYU

### DIFF
--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -3372,6 +3372,15 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, StringRef& reply)
 					move.SetKinematics(KinematicsType::coreXZ);
 					break;
 
+				case 3:
+					if (numTotalAxes < 5) {
+						platform.MessageF(GENERIC_MESSAGE, "Error: U and V axis must be defined using M584 before M668 command\n", mode);
+					 	error = true;
+					 	return true;
+					}
+					move.SetKinematics(KinematicsType::coreXYU);
+					break;
+
 				default:
 					platform.MessageF(GENERIC_MESSAGE, "Error: mode %d is not value in M667 command\n", mode);
 					error = true;

--- a/src/Movement/Kinematics/CoreXYUKinematics.cpp
+++ b/src/Movement/Kinematics/CoreXYUKinematics.cpp
@@ -27,7 +27,7 @@ const char *CoreXYUKinematics::GetName(bool forStatusReport) const
 // This function is used for CoreXY and CoreXZ kinematics, but it overridden for CoreXYU kinematics
 bool CoreXYUKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, StringRef& reply, bool& error) /*override*/
 {
-	if (mCode == 668)
+	if (mCode == 667)
 	{
 		bool seen = false;
 		for (size_t axis = 0; axis < CoreXYU_AXES; ++axis)
@@ -36,6 +36,10 @@ bool CoreXYUKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, StringRef
 			{
 				axisFactors[axis] = gb.GetFValue();
 				seen = true;
+			}
+			else
+			{
+				axisFactors[axis] = 1.0;
 			}
 		}
 		if (!seen && !gb.Seen('S'))
@@ -81,7 +85,7 @@ void CoreXYUKinematics::MotorStepsToCartesian(const int32_t motorPos[], const fl
 bool CoreXYUKinematics::DriveIsShared(size_t drive) const
 {
 	return drive == X_AXIS || drive == Y_AXIS
-			|| drive == U_AXIS || drive == V_AXIS;			// U and V don't have endstop switches, but include them here just in case
+			|| drive == U_AXIS || drive == V_AXIS;			// X, Y and U has endstops. V don't have endstop switches, but include them here just in case
 }
 
 // Calculate the movement fraction for a single axis motor


### PR DESCRIPTION
There is no way to activate CoreXYU in beta 7.
M667 S3 is now used to set up CoreXYU.
"axisFactors[axis]" is set to 1.0 for all of the CoreXUY axis if not specified on M667.