### PR TITLE
Save max pwm after the auto tune is completed

### DIFF
--- a/src/Heating/Pid.cpp
+++ b/src/Heating/Pid.cpp
@@ -808,7 +808,7 @@ void PID::CalculateModel()
 	const float heatingTime = (tuningHeatingTime - tuningPeakDelay) * 0.001;
 	const float gain = (tuningHeaterOffTemp - tuningStartTemp)/(1.0 - exp(-heatingTime/tc));
 
-	tuned = SetModel(gain, tc, td, model.GetMaxPwm(), true);
+	tuned = SetModel(gain, tc, td, tuningPwm, true);
 	if (tuned)
 	{
 		platform.MessageF(GENERIC_MESSAGE,


### PR DESCRIPTION
Currently, max pwm parameter in auto tune is ignored after the auto tune is completed. This PR makes max pwm persistent. So after the auto tune is completed, correct pwm is reported and saved to the config-override file.