### PR TITLE
fix reported speeds for thermostatically-controlled fans

### DIFF
--- a/src/Fan.cpp
+++ b/src/Fan.cpp
@@ -143,7 +143,10 @@ bool Fan::Configure(unsigned int mcode, int fanNum, GCodeBuffer& gb, const Strin
 							(inverted) ? "yes" : "no");
 			if (heatersMonitored != 0)
 			{
-				reply.catf(", temperature: %.1f:%.1fC, heaters:", (double)triggerTemperatures[0], (double)triggerTemperatures[1]);
+				reply.catf(", actual-speed: %d%%, temperature: %.1f:%.1fC, heaters:",
+					(int)(lastVal * 100.0),
+					(double)triggerTemperatures[0],
+					(double)triggerTemperatures[1]);
 				for (unsigned int i = 0; i < Heaters + MaxVirtualHeaters; ++i)
 				{
 					if (IsBitSet(heatersMonitored, i))


### PR DESCRIPTION
M408 always reports 100% fan speed for thermostatically-controlled fans. Even though it may be 0% if the heaters are off and the temperature is low enough.

This PR resolves this by reporting the actual fan speed that is currently set.
I also made changes to `Fan::SetValue`, because pause/resume/init functionality might be affected by the new reported value. As previously implemented, `Fan::SetValue` always sets the fan to 100% if it is thermostatically-controlled, with the idea that in the next `Refresh` cycle, the correct speed will be enacted again.