### PR TITLE
debounce (wait msecs) option for pulse type filament monitors

### DIFF
--- a/src/FilamentMonitors/PulsedFilamentMonitor.cpp
+++ b/src/FilamentMonitors/PulsedFilamentMonitor.cpp
@@ -97,7 +97,7 @@ bool PulsedFilamentMonitor::Configure(GCodeBuffer& gb, const StringRef& reply, b
 		else
 		{
                   reply.catf("current position %.1f, ", (double) GetCurrentPosition());
-                  if (calibrationStarted && fabsf(totalMovementMeasured) > 1.0 && totalExtrusionCommanded > 1.0 /*20.0*/)
+                  if (calibrationStarted && fabsf(totalMovementMeasured) > 1.0 && totalExtrusionCommanded > 20.0)
 			{
 				const float measuredMmPerPulse = totalExtrusionCommanded/totalMovementMeasured;
 				reply.catf("measured sensitivity %.3fmm/pulse, measured minimum %ld%%, maximum %ld%% over %.1fmm\n",

--- a/src/FilamentMonitors/PulsedFilamentMonitor.h
+++ b/src/FilamentMonitors/PulsedFilamentMonitor.h
@@ -26,7 +26,8 @@ private:
 	static constexpr float DefaultMinMovementAllowed = 0.6;
 	static constexpr float DefaultMaxMovementAllowed = 1.6;
 	static constexpr float DefaultMinimumExtrusionCheckLength = 5.0;
-
+        static constexpr uint32_t DefaultWaitMsec = 0;
+        
 	void Init();
 	void Reset();
 	void Poll();
@@ -38,6 +39,7 @@ private:
 	float minMovementAllowed, maxMovementAllowed;
 	float minimumExtrusionCheckLength;
 	bool comparisonEnabled;
+        uint32_t waitMsec;
 
 	// Other data
 	uint32_t sensorValue;									// how many pulses received


### PR DESCRIPTION
Add 'Wnnn' option for pulse type filament monitor to specify number of milliseconds to ignore subsequent pulses after an initial pulse is received.

Documentation change something like:

'''Additional parameters for a pulse generating filament monitor'''

* '''Lnn''' Filament movement per pulse in mm
* '''Wnnn''' Wait nnn milliseconds between counting pulses (debounce)
* ''S, R, E''' As for Duet3D laser filament monitor<