### PR TITLE
Add a maximum fan speed parameter and enforce it

### DIFF
--- a/src/Fans/Fan.h
+++ b/src/Fans/Fan.h
@@ -44,6 +44,7 @@ private:
 	float val;
 	float lastVal;
 	float minVal;
+	float maxVal;
 	float triggerTemperatures[2];
 	float lastPwm;
 	uint32_t blipTime;						// in milliseconds


### PR DESCRIPTION
This closes
https://forum.duet3d.com/topic/5726/m106-maximum-fan-speed-setting and https://forum.duet3d.com/topic/5370/m106-feature-request-limit-max-pwm-parameter
I have **not** compiled the code but as simple as this change is I don't think this was necessary.

AKAICT, these are the only two places where changes are needed, right?

Once you accept this PR I will also add this to Gcode wiki at dozuki for Duet and reprap.org to "officially" reserve the `M` parameter for `M106`.