### PR TITLE
Allow configuration of extrusion and retraction minimum temperatures

### DIFF
--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -2260,15 +2260,29 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 		SetPidParameters(gb, 1, reply);
 		break;
 
-	case 302: // Allow, deny or report cold extrudes
-		if (gb.Seen('P'))
+	case 302: // Allow, deny or report cold extrudes and configure minimum extrusion/retraction temps
 		{
-			reprap.GetHeat().AllowColdExtrude(gb.GetIValue() > 0);
-		}
-		else
-		{
-			reply.printf("Cold extrusion is %s, use M302 P[1/0] to allow/deny it",
-					reprap.GetHeat().ColdExtrude() ? "allowed" : "denied");
+			bool seen = false;
+			if (gb.Seen('P'))
+			{
+				seen = true;
+				reprap.GetHeat().AllowColdExtrude(gb.GetIValue() > 0);
+			}
+			if (gb.Seen('S'))
+			{
+				seen = true;
+				reprap.GetHeat().SetExtrusionMinTemp(gb.GetFValue());
+			}
+			if (gb.Seen('R'))
+			{
+				seen = true;
+				reprap.GetHeat().SetRetractionMinTemp(gb.GetFValue());
+			}
+			if (!seen)
+			{
+				reply.printf("Cold extrusion is %s (use M302 P[1/0] to allow/deny it), min. extrusion temp is %.1f, min. retraction temp is %.1f",
+						reprap.GetHeat().ColdExtrude() ? "allowed" : "denied", (double)reprap.GetHeat().GetExtrusionMinTemp(), (double)reprap.GetHeat().GetRetractionMinTemp());
+			}
 		}
 		break;
 

--- a/src/Heating/Heat.cpp
+++ b/src/Heating/Heat.cpp
@@ -149,6 +149,8 @@ void Heat::Init()
 	DhtSensorHardwareInterface::InitStatic();
 #endif
 
+	extrusionMinTemp = HOT_ENOUGH_TO_EXTRUDE;
+	retractionMinTemp = HOT_ENOUGH_TO_RETRACT;
 	coldExtrude = false;
 
 #ifdef RTOS

--- a/src/Heating/Heat.h
+++ b/src/Heating/Heat.h
@@ -52,6 +52,10 @@ public:
 
 	bool ColdExtrude() const;									// Is cold extrusion allowed?
 	void AllowColdExtrude(bool b);								// Allow or deny cold extrusion
+	float GetExtrusionMinTemp() const;							// Get minimum extrusion temperature
+	float GetRetractionMinTemp() const;							// Get minimum retraction temperature
+	void SetExtrusionMinTemp(float t);							// Set minimum extrusion temperature
+	void SetRetractionMinTemp(float t);							// Set minimum retraction temperature
 
 	int8_t GetBedHeater(size_t index) const						// Get a hot bed heater number
 	pre(index < NumBedHeaters);
@@ -173,6 +177,8 @@ private:
 	bool active;												// Are we active?
 #endif
 
+	float extrusionMinTemp;										// Minimum temperature to allow regular extrusion
+	float retractionMinTemp;									// Minimum temperature to allow regular retraction
 	bool coldExtrude;											// Is cold extrusion allowed?
 	int8_t bedHeaters[NumBedHeaters];							// Indices of the hot bed heaters to use or -1 if none is available
 	int8_t chamberHeaters[NumChamberHeaters];					// Indices of the chamber heaters to use or -1 if none is available
@@ -190,6 +196,26 @@ inline bool Heat::ColdExtrude() const
 inline void Heat::AllowColdExtrude(bool b)
 {
 	coldExtrude = b;
+}
+
+inline float Heat::GetExtrusionMinTemp() const
+{
+	return extrusionMinTemp;
+}
+
+inline float Heat::GetRetractionMinTemp() const
+{
+	return retractionMinTemp;
+}
+
+inline void Heat::SetExtrusionMinTemp(float t)
+{
+	extrusionMinTemp = t;
+}
+
+inline void Heat::SetRetractionMinTemp(float t)
+{
+	retractionMinTemp = t;
 }
 
 inline int8_t Heat::GetBedHeater(size_t index) const

--- a/src/RepRap.cpp
+++ b/src/RepRap.cpp
@@ -2143,7 +2143,7 @@ unsigned int RepRap::GetProhibitedExtruderMovements(unsigned int extrusions, uns
 	Tool * const tool = currentTool;
 	if (tool == nullptr)
 	{
-		// This should not happen, but if on tool is selected then don't allow any extruder movement
+		// This should not happen, but if no tool is selected then don't allow any extruder movement
 		return extrusions | retractions;
 	}
 

--- a/src/Tools/Tool.cpp
+++ b/src/Tools/Tool.cpp
@@ -288,7 +288,7 @@ bool Tool::AllHeatersAtHighTemperature(bool forExtrusion) const
 	for (size_t heater = 0; heater < heaterCount; heater++)
 	{
 		const float temperature = reprap.GetHeat().GetTemperature(heaters[heater]);
-		if (temperature < HOT_ENOUGH_TO_RETRACT || (temperature < HOT_ENOUGH_TO_EXTRUDE && forExtrusion))
+		if (temperature < reprap.GetHeat().GetRetractionMinTemp() || (forExtrusion && temperature < reprap.GetHeat().GetExtrusionMinTemp()))
 		{
 			return false;
 		}


### PR DESCRIPTION
This fixes https://forum.duet3d.com/topic/5735/set-extrusion-min-temp

I don't know if this was intentional in the first to have these values hard-coded and not configurable so I implemented this as a "you decide", i.e. I won't be mad if you decline this PR - in that case it was just a nice practice for my C++ skills as well as getting more into the code structure of RRF. :-)

So as I said, you decide. ;-)

As with the other PR that needs amendment of the G-code wiki: if you decide to merge, I will also do those changes.