### PR TITLE
C param for ZProbe Mode 4

### DIFF
--- a/src/GCodes/GCodes3.cpp
+++ b/src/GCodes/GCodes3.cpp
@@ -428,7 +428,6 @@ GCodeResult GCodes::SetOrReportZProbe(GCodeBuffer& gb, const StringRef &reply)
 	{
 		platform.SetZProbeType(gb.GetIValue());
 		seenType = true;
-		DoDwellTime(gb, 100);				// delay a little to allow the averaging filters to accumulate data from the new source
 	}
 
 	ZProbe params = platform.GetCurrentZProbeParameters();
@@ -467,9 +466,21 @@ GCodeResult GCodes::SetOrReportZProbe(GCodeBuffer& gb, const StringRef &reply)
 		seenParam = true;
 	}
 
+	if (gb.Seen('E'))
+	{
+		params.eEndstop = gb.GetUIValue();
+		seenParam = true;
+	}
+
 	if (seenParam)
 	{
 		platform.SetZProbeParameters(platform.GetZProbeType(), params);
+	}
+
+	if (seenParam || seenType)
+	{
+		platform.InitZProbe();
+		DoDwellTime(gb, 100);				// delay a little to allow the averaging filters to accumulate data from the new source
 	}
 
 	if (!(seenType || seenParam))

--- a/src/GCodes/GCodes3.cpp
+++ b/src/GCodes/GCodes3.cpp
@@ -466,9 +466,9 @@ GCodeResult GCodes::SetOrReportZProbe(GCodeBuffer& gb, const StringRef &reply)
 		seenParam = true;
 	}
 
-	if (gb.Seen('E'))
+	if (gb.Seen('C'))
 	{
-		params.eEndstop = gb.GetUIValue();
+		params.endstop = gb.GetUIValue();
 		seenParam = true;
 	}
 

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -615,7 +615,7 @@ void Platform::InitZProbe()
 		pinMode(zProbeModulationPin, OUTPUT_LOW);		// enable the alternate sensor
 		break;
 
-	case ZProbeType::e0Switch:
+	case ZProbeType::eSwitch:
 		AnalogInEnableChannel(zProbeAdcChannel, false);
 		pinMode(zProbePin, INPUT_PULLUP);
 		pinMode(endStopPins[E0_AXIS + GetCurrentZProbeParameters().eEndstop], INPUT);
@@ -629,13 +629,6 @@ void Platform::InitZProbe()
 	default:
 		AnalogInEnableChannel(zProbeAdcChannel, false);
 		pinMode(zProbePin, INPUT_PULLUP);
-		pinMode(zProbeModulationPin, OUTPUT_LOW);		// we now set the modulation output high during probing only when using probe types 4 and higher
-		break;
-
-	case ZProbeType::e1Switch:
-		AnalogInEnableChannel(zProbeAdcChannel, false);
-		pinMode(zProbePin, INPUT_PULLUP);
-		pinMode(endStopPins[E0_AXIS + 1], INPUT);
 		pinMode(zProbeModulationPin, OUTPUT_LOW);		// we now set the modulation output high during probing only when using probe types 4 and higher
 		break;
 
@@ -659,9 +652,8 @@ int Platform::GetZProbeReading() const
 		{
 		case ZProbeType::analog:				// Simple or intelligent IR sensor
 		case ZProbeType::alternateAnalog:		// Alternate sensor
-		case ZProbeType::e0Switch:				// Switch connected to E0 endstop input
+		case ZProbeType::eSwitch:				// Switch connected to E[n] endstop input
 		case ZProbeType::digital:				// Switch connected to Z probe input
-		case ZProbeType::e1Switch:				// Switch connected to E1 endstop input
 		case ZProbeType::zSwitch:				// Switch connected to Z endstop input
 		case ZProbeType::blTouch:
 			zProbeVal = (int) ((zProbeOnFilter.GetSum() + zProbeOffFilter.GetSum()) / (8 * Z_PROBE_AVERAGE_READINGS));
@@ -757,6 +749,8 @@ float Platform::GetZProbeTravelSpeed() const
 
 void Platform::SetZProbeType(unsigned int pt)
 {
+	if(pt == (unsigned int)ZProbeType::e1Switch)
+		pt = (unsigned int)ZProbeType::eSwitch;
 	zProbeType = (pt < (unsigned int)ZProbeType::numTypes) ? (ZProbeType)pt : ZProbeType::none;
 }
 
@@ -782,8 +776,7 @@ const ZProbe& Platform::GetZProbeParameters(ZProbeType probeType) const
 		return irZProbeParameters;
 	case ZProbeType::alternateAnalog:
 		return alternateZProbeParameters;
-	case ZProbeType::e0Switch:
-	case ZProbeType::e1Switch:
+	case ZProbeType::eSwitch:
 	case ZProbeType::zSwitch:
 	default:
 		return switchZProbeParameters;
@@ -807,8 +800,7 @@ void Platform::SetZProbeParameters(ZProbeType probeType, const ZProbe& params)
 		alternateZProbeParameters = params;
 		break;
 
-	case ZProbeType::e0Switch:
-	case ZProbeType::e1Switch:
+	case ZProbeType::eSwitch:
 	case ZProbeType::zSwitch:
 	default:
 		switchZProbeParameters = params;

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -749,9 +749,15 @@ float Platform::GetZProbeTravelSpeed() const
 
 void Platform::SetZProbeType(unsigned int pt)
 {
-	if(pt == (unsigned int)ZProbeType::e1Switch)
-		pt = (unsigned int)ZProbeType::eSwitch;
-	zProbeType = (pt < (unsigned int)ZProbeType::numTypes) ? (ZProbeType)pt : ZProbeType::none;
+	if(pt == (unsigned int)ZProbeType::e1Switch) //Backward compatibility for Mode 6
+	{
+		zProbeType = ZProbeType::eSwitch;
+		ZProbe params = GetCurrentZProbeParameters();
+		params.eEndstop = 1;
+		SetZProbeParameters(zProbeType, params);
+	}
+	else
+		zProbeType = (pt < (unsigned int)ZProbeType::numTypes) ? (ZProbeType)pt : ZProbeType::none;
 }
 
 void Platform::SetProbing(bool isProbing)

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -618,7 +618,7 @@ void Platform::InitZProbe()
 	case ZProbeType::eSwitch:
 		AnalogInEnableChannel(zProbeAdcChannel, false);
 		pinMode(zProbePin, INPUT_PULLUP);
-		pinMode(endStopPins[E0_AXIS + GetCurrentZProbeParameters().eEndstop], INPUT);
+		pinMode(endStopPins[GetCurrentZProbeParameters().endstop], INPUT);
 		pinMode(zProbeModulationPin, OUTPUT_LOW);		// we now set the modulation output high during probing only when using probe types 4 and higher
 		break;
 
@@ -753,7 +753,7 @@ void Platform::SetZProbeType(unsigned int pt)
 	{
 		zProbeType = ZProbeType::eSwitch;
 		ZProbe params = GetCurrentZProbeParameters();
-		params.eEndstop = 1;
+		params.endstop = 4;
 		SetZProbeParameters(zProbeType, params);
 	}
 	else

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -618,7 +618,7 @@ void Platform::InitZProbe()
 	case ZProbeType::e0Switch:
 		AnalogInEnableChannel(zProbeAdcChannel, false);
 		pinMode(zProbePin, INPUT_PULLUP);
-		pinMode(endStopPins[E0_AXIS], INPUT);
+		pinMode(endStopPins[E0_AXIS + GetCurrentZProbeParameters().eEndstop], INPUT);
 		pinMode(zProbeModulationPin, OUTPUT_LOW);		// we now set the modulation output high during probing only when using probe types 4 and higher
 		break;
 
@@ -758,7 +758,6 @@ float Platform::GetZProbeTravelSpeed() const
 void Platform::SetZProbeType(unsigned int pt)
 {
 	zProbeType = (pt < (unsigned int)ZProbeType::numTypes) ? (ZProbeType)pt : ZProbeType::none;
-	InitZProbe();
 }
 
 void Platform::SetProbing(bool isProbing)

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -1177,7 +1177,7 @@ inline uint16_t Platform::GetRawZProbeReading() const
 	case ZProbeType::alternateAnalog:
 		return min<uint16_t>(AnalogInReadChannel(zProbeAdcChannel), 4000);
 
-	case ZProbeType::e0Switch:
+	case ZProbeType::eSwitch:
 		{
 			uint8_t eEndstop = GetCurrentZProbeParameters().eEndstop;
 			const bool b = IoPort::ReadPin(endStopPins[E0_AXIS + eEndstop]);
@@ -1188,12 +1188,6 @@ inline uint16_t Platform::GetRawZProbeReading() const
 	case ZProbeType::unfilteredDigital:
 	case ZProbeType::blTouch:
 		return (IoPort::ReadPin(zProbePin)) ? 4000 : 0;
-
-	case ZProbeType::e1Switch:
-		{
-			const bool b = IoPort::ReadPin(endStopPins[E0_AXIS + 1]);
-			return (b) ? 4000 : 0;
-		}
 
 	case ZProbeType::zSwitch:
 		{

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -1179,8 +1179,8 @@ inline uint16_t Platform::GetRawZProbeReading() const
 
 	case ZProbeType::eSwitch:
 		{
-			uint8_t eEndstop = GetCurrentZProbeParameters().eEndstop;
-			const bool b = IoPort::ReadPin(endStopPins[E0_AXIS + eEndstop]);
+			uint8_t endstop = GetCurrentZProbeParameters().endstop;
+			const bool b = IoPort::ReadPin(endStopPins[endstop]);
 			return (b) ? 4000 : 0;
 		}
 

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -492,6 +492,7 @@ public:
 	void SetProbing(bool isProbing);
 	bool ProgramZProbe(GCodeBuffer& gb, const StringRef& reply);
 	void SetZProbeModState(bool b) const;
+	void InitZProbe();
 
 	// Heat and temperature
 	float GetZProbeTemperature();							// Get our best estimate of the Z probe temperature
@@ -790,7 +791,6 @@ private:
 	float mcuTemperatureAdjust;
 #endif
 
-	void InitZProbe();
 	uint16_t GetRawZProbeReading() const;
 	void UpdateNetworkAddress(uint8_t dst[4], const uint8_t src[4]);
 
@@ -1179,7 +1179,8 @@ inline uint16_t Platform::GetRawZProbeReading() const
 
 	case ZProbeType::e0Switch:
 		{
-			const bool b = IoPort::ReadPin(endStopPins[E0_AXIS]);
+			uint8_t eEndstop = GetCurrentZProbeParameters().eEndstop;
+			const bool b = IoPort::ReadPin(endStopPins[E0_AXIS + eEndstop]);
 			return (b) ? 4000 : 0;
 		}
 

--- a/src/ZProbe.cpp
+++ b/src/ZProbe.cpp
@@ -24,7 +24,7 @@ void ZProbe::Init(float h)
 	tolerance = DefaultZProbeTolerance;
 	maxTaps = DefaultZProbeTaps;
 	invertReading = turnHeatersOff = false;
-	eEndstop = 0;
+	eEndstop = 1; // Default e1 for Mode 6 backward compatibility
 }
 
 float ZProbe::GetStopHeight(float temperature) const

--- a/src/ZProbe.cpp
+++ b/src/ZProbe.cpp
@@ -24,7 +24,7 @@ void ZProbe::Init(float h)
 	tolerance = DefaultZProbeTolerance;
 	maxTaps = DefaultZProbeTaps;
 	invertReading = turnHeatersOff = false;
-	eEndstop = 0; // Default e0 for Mode 4 backward compatibility
+	endstop = 3; // Default e0 for Mode 4 backward compatibility
 }
 
 float ZProbe::GetStopHeight(float temperature) const
@@ -37,10 +37,10 @@ bool ZProbe::WriteParameters(FileStore *f, unsigned int probeType) const
 	String<ScratchStringLength> scratchString;
 	if(probeType != (unsigned int)ZProbeType::eSwitch)
 		scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f", probeType, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight);
-	else if(eEndstop == 1)
+	else if(endstop == 4)
 		scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f", (unsigned int)ZProbeType::e1Switch, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight);
 	else
-		scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f E%u\n", probeType, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight, eEndstop);
+		scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f C%u\n", probeType, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight, endstop);
 
 	return f->Write(scratchString.c_str());
 }

--- a/src/ZProbe.cpp
+++ b/src/ZProbe.cpp
@@ -24,6 +24,7 @@ void ZProbe::Init(float h)
 	tolerance = DefaultZProbeTolerance;
 	maxTaps = DefaultZProbeTaps;
 	invertReading = turnHeatersOff = false;
+	eEndstop = 0;
 }
 
 float ZProbe::GetStopHeight(float temperature) const
@@ -34,7 +35,7 @@ float ZProbe::GetStopHeight(float temperature) const
 bool ZProbe::WriteParameters(FileStore *f, unsigned int probeType) const
 {
 	String<ScratchStringLength> scratchString;
-	scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f\n", probeType, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight);
+	scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f E%u\n", probeType, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight, eEndstop);
 	return f->Write(scratchString.c_str());
 }
 

--- a/src/ZProbe.cpp
+++ b/src/ZProbe.cpp
@@ -24,7 +24,7 @@ void ZProbe::Init(float h)
 	tolerance = DefaultZProbeTolerance;
 	maxTaps = DefaultZProbeTaps;
 	invertReading = turnHeatersOff = false;
-	eEndstop = 1; // Default e1 for Mode 6 backward compatibility
+	eEndstop = 0; // Default e0 for Mode 4 backward compatibility
 }
 
 float ZProbe::GetStopHeight(float temperature) const
@@ -35,7 +35,13 @@ float ZProbe::GetStopHeight(float temperature) const
 bool ZProbe::WriteParameters(FileStore *f, unsigned int probeType) const
 {
 	String<ScratchStringLength> scratchString;
-	scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f E%u\n", probeType, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight, eEndstop);
+	if(probeType != (unsigned int)ZProbeType::eSwitch)
+		scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f", probeType, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight);
+	else if(eEndstop == 1)
+		scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f", (unsigned int)ZProbeType::e1Switch, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight);
+	else
+		scratchString.printf("G31 T%u P%" PRIu32 " X%.1f Y%.1f Z%.2f E%u\n", probeType, adcValue, (double)xOffset, (double)yOffset, (double)triggerHeight, eEndstop);
+
 	return f->Write(scratchString.c_str());
 }
 

--- a/src/ZProbe.h
+++ b/src/ZProbe.h
@@ -16,9 +16,9 @@ enum class ZProbeType : uint8_t
 	analog = 1,
 	dumbModulated = 2,
 	alternateAnalog = 3,
-	e0Switch = 4,
+	eSwitch = 4,
 	digital = 5,
-	e1Switch = 6,
+	e1Switch = 6, //Deprecated
 	zSwitch = 7,
 	unfilteredDigital = 8,
 	blTouch = 9,

--- a/src/ZProbe.h
+++ b/src/ZProbe.h
@@ -42,6 +42,7 @@ public:
 	uint8_t maxTaps;				// maximum probes at each point
 	bool invertReading;				// true if we need to invert the reading
 	bool turnHeatersOff;			// true to turn heaters off while probing
+	uint8_t eEndstop;                  // E endstop to use with P4;
 
 	void Init(float h);
 	float GetStopHeight(float temperature) const;

--- a/src/ZProbe.h
+++ b/src/ZProbe.h
@@ -42,7 +42,7 @@ public:
 	uint8_t maxTaps;				// maximum probes at each point
 	bool invertReading;				// true if we need to invert the reading
 	bool turnHeatersOff;			// true to turn heaters off while probing
-	uint8_t eEndstop;                  // E endstop to use with P4;
+	uint8_t endstop;                //endstop channel to use with P4;
 
 	void Init(float h);
 	float GetStopHeight(float temperature) const;


### PR DESCRIPTION
Add param so user can choose which Endstop switch to use as a Zprobe input for Mode 4.
Deprecated Mode 6 (fallback to Mode 4 with E1 switch)