### PR TITLE
Fix include for case-sensitive file-systems

### DIFF
--- a/src/Fans/DotStarLed.h
+++ b/src/Fans/DotStarLed.h
@@ -8,7 +8,7 @@
 #ifndef SRC_FANS_DOTSTARLED_H_
 #define SRC_FANS_DOTSTARLED_H_
 
-#include "ReprapFirmware.h"
+#include "RepRapFirmware.h"
 #include "GCodes/GCodeResult.h"
 
 class GCodeBuffer;

--- a/src/StepperDrivers/TMC22xx/TMC22xx.cpp
+++ b/src/StepperDrivers/TMC22xx/TMC22xx.cpp
@@ -5,7 +5,7 @@
  *      Author: David
  */
 
-#include "ReprapFirmware.h"
+#include "RepRapFirmware.h"
 
 #if SUPPORT_TMC22xx
 

--- a/src/StepperDrivers/TMC2660/TMC2660.cpp
+++ b/src/StepperDrivers/TMC2660/TMC2660.cpp
@@ -5,7 +5,7 @@
  *      Author: David
  */
 
-#include "ReprapFirmware.h"
+#include "RepRapFirmware.h"
 
 #if SUPPORT_TMC2660
 


### PR DESCRIPTION
On Linux machines (and most probably also on MacOS) there was a compiler error because it could not find the import of `ReprapFirmware.h` because the file is named `RepRapFirmware.h` (note the capital R of "Rap"). Windows does not care but case-sensitive file-systems do.