### PR TITLE
Fixes typo

### DIFF
--- a/src/CAN/CanMessageBuffer.h
+++ b/src/CAN/CanMessageBuffer.h
@@ -8,7 +8,7 @@
 #ifndef SRC_CAN_CANMESSAGEBUFFER_H_
 #define SRC_CAN_CANMESSAGEBUFFER_H_
 
-#include "ReprapFirmware.h"
+#include "RepRapFirmware.h"
 
 #if SUPPORT_CAN_EXPANSION
 


### PR DESCRIPTION
Fixes a typo in
```
#include "RepRapFirmware.h"
```

This makes the project compile.

Another fix that lets the project compile for me is to just comment out the line.