### PR TITLE
Special Case Bug Fix (Smart Drivers / Voltage Monitoring)

### DIFF
--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -137,7 +137,7 @@ void GCodes::Init()
 	axisLetters[1] = 'Y';
 	axisLetters[2] = 'Z';
 
-#if defined(DUET_NG) || defined(DUET_M)
+#if HAS_SMART_DRIVERS
 	numExtruders = min<size_t>(MaxExtruders, platform.GetNumSmartDrivers() - XYZ_AXES);	// don't default dumb drivers to extruders because they don't support the same microstepping options
 #else
 	numExtruders = MaxExtruders;

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -450,6 +450,8 @@ void Platform::Init()
 	// The SX1509B has an independent power on reset, so give it some time
 	delay(200);
 	expansionBoard = DuetExpansion::DueXnInit();
+
+#if HAS_SMART_DRIVERS
 	switch (expansionBoard)
 	{
 	case ExpansionBoardType::DueX2:
@@ -464,6 +466,7 @@ void Platform::Init()
 		numSmartDrivers = 5;									// assume that any additional drivers are dumb enable/step/dir ones
 		break;
 	}
+#endif
 
 	if (expansionBoard != ExpansionBoardType::none)
 	{
@@ -1765,7 +1768,11 @@ bool Platform::IsPowerOk() const
 
 bool Platform::HasVinPower() const
 {
+#if HAS_SMART_DRIVERS
 	return driversPowered;			// not quite right because drivers are disabled if we get over-voltage too, but OK for the status report
+#else
+	return true;
+#endif
 }
 
 void Platform::EnableAutoSave(float saveVoltage, float resumeVoltage)
@@ -2297,7 +2304,7 @@ void Platform::Diagnostics(MessageType mtype)
 	MessageF(mtype, "Supply voltage: min %.1f, current %.1f, max %.1f, under voltage events: %" PRIu32 ", over voltage events: %" PRIu32 ", power good: %s\n",
 		(double)AdcReadingToPowerVoltage(lowestVin), (double)AdcReadingToPowerVoltage(currentVin), (double)AdcReadingToPowerVoltage(highestVin),
 				numUnderVoltageEvents, numOverVoltageEvents,
-				(driversPowered) ? "yes" : "no");
+				(HasVinPower()) ? "yes" : "no");
 	lowestVin = highestVin = currentVin;
 #endif
 


### PR DESCRIPTION
Bug fixes that allow for Smart Drivers to be disabled, while maintaining voltage monitoring. This is really only a specific use case, but when support for Smart Drivers (TMC2660 or similar) is turned off, but Voltage Monitoring is turned on, there will be errors during compiling due to a few incorrect flags.

This works with Duet_NG, but I have not tested with Duet_M.