### PR TITLE
Add a parameter Snnn to M92 that indicates the microstepping factor

### DIFF
--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -3740,7 +3740,7 @@ bool GCodes::ChangeMicrostepping(size_t drive, unsigned int microsteps, bool int
 	if (success)
 	{
 		// We changed the microstepping, so adjust the steps/mm to compensate
-		platform.SetDriveStepsPerUnit(drive, platform.DriveStepsPerUnit(drive) * (float)microsteps / (float)oldSteps);
+		platform.SetDriveStepsPerUnit(drive, platform.DriveStepsPerUnit(drive), oldSteps);
 	}
 	return success;
 }

--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -1124,8 +1124,8 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 	case 92: // Set/report steps/mm for some axes
 		{
 			bool seenUstepMultiplier = false;
-			int32_t ustepMultiplier;
-			gb.TryGetIValue('F', ustepMultiplier, seenUstepMultiplier);
+			uint32_t ustepMultiplier = 0;
+			gb.TryGetUIValue('S', ustepMultiplier, seenUstepMultiplier);
 
 			bool seen = false;
 			for (size_t axis = 0; axis < numTotalAxes; axis++)
@@ -1136,14 +1136,7 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 					{
 						return false;
 					}
-					if (seenUstepMultiplier)
-					{
-						platform.SetDriveStepsPerUnitForMicrostepping(axis, gb.GetFValue(), (unsigned int) ustepMultiplier);
-					}
-					else
-					{
-						platform.SetDriveStepsPerUnit(axis, gb.GetFValue());
-					}
+					platform.SetDriveStepsPerUnit(axis, gb.GetFValue(), ustepMultiplier);
 					seen = true;
 				}
 			}
@@ -1162,14 +1155,7 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 				// The user may not have as many extruders as we allow for, so just set the ones for which a value is provided
 				for (size_t e = 0; e < eCount; e++)
 				{
-					if (seenUstepMultiplier)
-					{
-						platform.SetDriveStepsPerUnitForMicrostepping(numTotalAxes + e, eVals[e], (unsigned int) ustepMultiplier);
-					}
-					else
-					{
-						platform.SetDriveStepsPerUnit(numTotalAxes + e, eVals[e]);
-					}
+					platform.SetDriveStepsPerUnit(numTotalAxes + e, eVals[e], ustepMultiplier);
 				}
 			}
 

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -3201,15 +3201,18 @@ void Platform::SetIdleCurrentFactor(float f)
 	}
 }
 
-void Platform::SetDriveStepsPerUnitForMicrostepping(size_t axisOrExtruder, float value, unsigned int microstepping)
+void Platform::SetDriveStepsPerUnit(size_t axisOrExtruder, float value, uint32_t microstepping)
 {
-	bool dummy;
-	const unsigned int currentMicrostepping = GetMicrostepping(axisOrExtruder, dummy);
-	if (currentMicrostepping != microstepping)
+	if (microstepping > 0)
 	{
-		value = value * (float)currentMicrostepping / (float)microstepping;
+		bool dummy;
+		const unsigned int currentMicrostepping = GetMicrostepping(axisOrExtruder, dummy);
+		if (currentMicrostepping != microstepping)
+		{
+			value = value * (float)currentMicrostepping / (float)microstepping;
+		}
 	}
-	SetDriveStepsPerUnit(axisOrExtruder, value);
+	driveStepsPerUnit[axisOrExtruder] = max<float>(value, 1.0);	// don't allow zero or negative
 }
 
 // Set the microstepping for a driver, returning true if successful

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -3201,6 +3201,17 @@ void Platform::SetIdleCurrentFactor(float f)
 	}
 }
 
+void Platform::SetDriveStepsPerUnitForMicrostepping(size_t axisOrExtruder, float value, unsigned int microstepping)
+{
+	bool dummy;
+	const unsigned int currentMicrostepping = GetMicrostepping(axisOrExtruder, dummy);
+	if (currentMicrostepping != microstepping)
+	{
+		value = value * (float)currentMicrostepping / (float)microstepping;
+	}
+	SetDriveStepsPerUnit(axisOrExtruder, value);
+}
+
 // Set the microstepping for a driver, returning true if successful
 bool Platform::SetDriverMicrostepping(size_t driver, unsigned int microsteps, int mode)
 {

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -416,8 +416,7 @@ public:
 	float DriveStepsPerUnit(size_t axisOrExtruder) const;
 	const float *GetDriveStepsPerUnit() const
 		{ return driveStepsPerUnit; }
-	void SetDriveStepsPerUnit(size_t axisOrExtruder, float value);
-	void SetDriveStepsPerUnitForMicrostepping(size_t axisOrExtruder, float value, unsigned int microstepping);
+	void SetDriveStepsPerUnit(size_t axisOrExtruder, float value, uint32_t microstepping);
 	float Acceleration(size_t axisOrExtruder) const;
 	const float* Accelerations() const;
 	void SetAcceleration(size_t axisOrExtruder, float value);
@@ -960,11 +959,6 @@ inline const char* Platform::GetDefaultFile() const
 inline float Platform::DriveStepsPerUnit(size_t drive) const
 {
 	return driveStepsPerUnit[drive];
-}
-
-inline void Platform::SetDriveStepsPerUnit(size_t drive, float value)
-{
-	driveStepsPerUnit[drive] = max<float>(value, 1.0);	// don't allow zero or negative
 }
 
 inline float Platform::Acceleration(size_t drive) const

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -417,6 +417,7 @@ public:
 	const float *GetDriveStepsPerUnit() const
 		{ return driveStepsPerUnit; }
 	void SetDriveStepsPerUnit(size_t axisOrExtruder, float value);
+	void SetDriveStepsPerUnitForMicrostepping(size_t axisOrExtruder, float value, unsigned int microstepping);
 	float Acceleration(size_t axisOrExtruder) const;
 	const float* Accelerations() const;
 	void SetAcceleration(size_t axisOrExtruder, float value);


### PR DESCRIPTION
This closes my request at: https://forum.duet3d.com/topic/8225/m92-parameter-to-indicate-microstepping

I was too impatient again. ;-)

I chose the parameter to be `Fnnn` just because I wanted to avoid `Mnnn` because of M-codes and `X` or `U` are already taken by axis names. So this is microstepping-`F`actor.