### PR TITLE
M308: Generic Heater Control

### DIFF
--- a/src/Heating/Heat.cpp
+++ b/src/Heating/Heat.cpp
@@ -743,4 +743,22 @@ bool Heat::WriteBedAndChamberTempSettings(FileStore *f) const
 	return (buf.strlen() == 0) || f->Write(buf.c_str());
 }
 
+const char *Heat::HeaterStatusToString(HeaterStatus status) const
+{
+	switch(status) {
+	case HeaterStatus::HS_off:
+		return "Off";
+	case HeaterStatus::HS_standby:
+		return "Standby";
+	case HeaterStatus::HS_active:
+		return "Active";
+	case HeaterStatus::HS_fault:
+		return "Fault";
+	case HeaterStatus::HS_tuning:
+		return "Tuning";
+	default:
+		return "unknown";
+	}
+}
+
 // End

--- a/src/Heating/Heat.h
+++ b/src/Heating/Heat.h
@@ -155,6 +155,8 @@ public:
 
 	void SuspendHeaters(bool sus);								// Suspend the heaters to conserve power
 
+	const char *HeaterStatusToString(HeaterStatus status) const;
+
 private:
 	Heat(const Heat&);											// Private copy constructor to prevent copying
 

--- a/src/Tools/Tool.cpp
+++ b/src/Tools/Tool.cpp
@@ -498,4 +498,17 @@ void Tool::IterateHeaters(std::function<void(int)> f) const
 	}
 }
 
+int Tool::GetHeaterAssignedToTool(int8_t global_heater) const
+{
+	for (size_t i = 0; i < heaterCount; i++)
+	{
+		if (heaters[i] == global_heater)
+		{
+			return i;
+		}
+	}
+
+	return -1;
+}
+
 // End

--- a/src/Tools/Tool.h
+++ b/src/Tools/Tool.h
@@ -84,6 +84,8 @@ public:
 	void IterateExtruders(std::function<void(unsigned int)> f) const;
 	void IterateHeaters(std::function<void(int)> f) const;
 
+	int GetHeaterAssignedToTool(int8_t global_heater) const;
+
 	friend class RepRap;
 
 protected:


### PR DESCRIPTION
Parameters:

 * Pnnn Heater index
 * Snnn Target active temperature  (note 1,3)
 * Rnnn Target standby temperature  (note 1,3)
 * Tnnn Heater state: 0 = off, 1 = standby 2 = on. (note 2,3)

This command allows direct control of heaters without having
to know whether a heater is a bed, chamber, tool or some other
type of heater.  It does not replace any existing G or M code
commands and is meant more for use from the command line and
by user interfaces.  Although nothing prevents it, this command
should not be used by slicers. They should continue to use the
standard control commands.

The P parameter is required and selects the heater.  There is no
default so the minimum command is M308 Pnnn which prints the
heater's current state, target active temperature, target standby
temperature and the current temperature as follows:

```
Heater 1 State: 'Off', Active temp: 225.0°, Standby temp: 190.0°,
Surrent temp: 23.2°"
```

The S and R parameters are optional and set the target active and
standby temperatures.

The T parameter is also optional and if supplied, sets the heater's
current state where 0 = off, 1 = standby 2 = on.

Examples:
 * M308 P0 S70 R50
   Set heater 0 (usually but not necessarily the bed) target
   active temperature to 70 and the target standby temperature
   to 50.  Since the T parameter is not supplied, the heater's
   current state is not altered.

 * M308 P0 T1
   Set heater 0 to standby.  Any previously set standby temperature
   is preserved, even if set by another command such as M140, M141,
   G10, etc.

 * M308 P1 S225
   Set heater 1 (an extruder maybe) target active temperature to
   225 leaving its target standby temperature and state alone.

Notes:
(1): Since the T parameter explicitly controls the state of the
     heater, no special importance is placed on temperatures less
     than -273.  They will NOT turn the heater off as they may in
     other commands.

(2): To prevent accidental disruption of a print, you can change
     the target temperatures of a heater assigned to the active
     tool but you cannot change its state.

(3): This command will return an error if an attempt is made
     to set the temperatures or state of a heater in "fault"
     or "tuning" state.  Use the appropriate commands to return
     the heater to a working state before re-issuing this command.