### PR TITLE
Add parameter W to allow scaling fan speed between min and max

### DIFF
--- a/src/Fans/Fan.h
+++ b/src/Fans/Fan.h
@@ -45,6 +45,7 @@ private:
 	float lastVal;
 	float minVal;
 	float maxVal;
+	bool scaling;                           // scale all speeds between min and max
 	float triggerTemperatures[2];
 	float lastPwm;
 	uint32_t blipTime;						// in milliseconds


### PR DESCRIPTION
This new option would give a choice to the user to have the speed being set as absolute or scaled between min and max as discussed in: https://forum.duet3d.com/topic/8864/m106-maximum-fan-speed-setting-unproportional

You did not respond to whether this OK or not. So as usual just reject it if you think it is not worth or a good idea adding. ;-)