### PR TITLE
Add parameter Onnn to G10

### DIFF
--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -3565,10 +3565,6 @@ GCodeResult GCodes::SetOrReportOffsets(GCodeBuffer &gb, const StringRef& reply)
 	}
 
 	bool settingOffset = false;
-	// Tool offsets will either be included in config-override.g
-	// if they are being loaded from there, i.e. while a M501 is in progress
-	// or if the parameter O (like in config-_O_verride.g) with value 1 has been given
-	bool includeWithM500 = (gb.MachineState().runningM501) || (gb.Seen('O') && gb.GetUIValue() == 1);
 	for (size_t axis = 0; axis < numVisibleAxes; ++axis)
 	{
 		if (gb.Seen(axisLetters[axis]))
@@ -3578,7 +3574,7 @@ GCodeResult GCodes::SetOrReportOffsets(GCodeBuffer &gb, const StringRef& reply)
 				return GCodeResult::notFinished;
 			}
 			settingOffset = true;
-			tool->SetOffset(axis, gb.GetFValue(), includeWithM500);
+			tool->SetOffset(axis, gb.GetFValue(), gb.MachineState().runningM501);
 		}
 	}
 
@@ -4798,14 +4794,38 @@ GCodeResult GCodes::WriteConfigOverrideFile(GCodeBuffer& gb, const StringRef& re
 		ok = reprap.GetHeat().WriteModelParameters(f);
 	}
 
+	// M500 can have a Pnn:nn parameter to enable extra data being saved
+	// P10 will enable saving of tool offsets even if they have not been determined via M585
+	bool p10 = false;
+
+	// P31 will include G31 Z probe value
+	bool p31 = false;
+	if (gb.Seen('P'))
+	{
+		uint32_t pVals[2];
+		size_t pCount = 2;
+		gb.GetUnsignedArray(pVals, pCount, false);
+		for (size_t i = 0; i < pCount; i++)
+		{
+			switch (pVals[i])
+			{
+				case 10:
+					p10 = true;
+					break;
+				case 31:
+					p31 = true;
+					break;
+			}
+		}
+	}
 	if (ok)
 	{
-		ok = platform.WritePlatformParameters(f, gb.Seen('P') && gb.GetIValue() == 31);
+		ok = platform.WritePlatformParameters(f, p31);
 	}
 
 	if (ok)
 	{
-		ok = reprap.WriteToolParameters(f);
+		ok = reprap.WriteToolParameters(f, p10);
 	}
 
 #if SUPPORT_WORKPLACE_COORDINATES

--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -3565,6 +3565,10 @@ GCodeResult GCodes::SetOrReportOffsets(GCodeBuffer &gb, const StringRef& reply)
 	}
 
 	bool settingOffset = false;
+	// Tool offsets will either be included in config-override.g
+	// if they are being loaded from there, i.e. while a M501 is in progress
+	// or if the parameter O (like in config-_O_verride.g) with value 1 has been given
+	bool includeWithM500 = (gb.MachineState().runningM501) || (gb.Seen('O') && gb.GetUIValue() == 1);
 	for (size_t axis = 0; axis < numVisibleAxes; ++axis)
 	{
 		if (gb.Seen(axisLetters[axis]))
@@ -3574,7 +3578,7 @@ GCodeResult GCodes::SetOrReportOffsets(GCodeBuffer &gb, const StringRef& reply)
 				return GCodeResult::notFinished;
 			}
 			settingOffset = true;
-			tool->SetOffset(axis, gb.GetFValue(), gb.MachineState().runningM501);
+			tool->SetOffset(axis, gb.GetFValue(), includeWithM500);
 		}
 	}
 

--- a/src/GCodes/GCodes3.cpp
+++ b/src/GCodes/GCodes3.cpp
@@ -277,10 +277,16 @@ GCodeResult GCodes::GetSetWorkplaceCoordinates(GCodeBuffer& gb, const StringRef&
 // Save any modified workplace coordinate offsets to file returning true if successful. Used by M500.
 bool GCodes::WriteWorkplaceCoordinates(FileStore *f) const
 {
+	bool written = false;
 	for (size_t cs = 0; cs < NumCoordinateSystems; ++cs)
 	{
 		String<ScratchStringLength> scratchString;
-		scratchString.printf("G10 L2 P%u", cs + 1);
+		if (!written)
+		{
+			scratchString.copy("; Workplace coordinates\n");
+			written = true;
+		}
+		scratchString.catf("G10 L2 P%u", cs + 1);
 		for (size_t axis = 0; axis < numVisibleAxes; ++axis)
 		{
 			scratchString.catf(" %c%.2f", axisLetters[axis], (double)workplaceCoordinates[cs][axis]);

--- a/src/RepRap.cpp
+++ b/src/RepRap.cpp
@@ -2311,7 +2311,7 @@ bool RepRap::WriteToolSettings(FileStore *f) const
 }
 
 // Save some information in config-override.g
-bool RepRap::WriteToolParameters(FileStore *f) const
+bool RepRap::WriteToolParameters(FileStore *f, const bool forceWrite) const
 {
 	bool ok = true, written = false;
 	MutexLocker lock(toolListMutex);
@@ -2329,7 +2329,7 @@ bool RepRap::WriteToolParameters(FileStore *f) const
 			scratchString.catf("G10 P%d", t->Number());
 			for (size_t axis = 0; axis < MaxAxes; ++axis)
 			{
-				if (IsBitSet(axesProbed, axis))
+				if (forceWrite || IsBitSet(axesProbed, axis))
 				{
 					scratchString.catf(" %c%.2f", gCodes->GetAxisLetters()[axis], (double)(t->GetOffset(axis)));
 				}

--- a/src/RepRap.h
+++ b/src/RepRap.h
@@ -128,7 +128,7 @@ public:
 	void ClearAlert();
 
 	bool WriteToolSettings(FileStore *f) const;				// save some information for the resume file
-	bool WriteToolParameters(FileStore *f) const;			// save some information in config-override.g
+	bool WriteToolParameters(FileStore *f, const bool forceWrite) const;			// save some information in config-override.g
 
 	void ReportInternalError(const char *file, const char *func, int line) const;	// Report an internal error
 


### PR DESCRIPTION
If set to 1 this will mark the offset values passed by this command to
be included in a later M500 call, i.e. being saved to config-override.g.
Currently this is only the case when offsets have been probed via M585.

Also add a header line for Workplace coordinates in config-override.g.

This has not been discussed prior in the forums but is required for the ongoing OEM work.

P.S.: Once accepted I will extend the documentation as usual.