### PR TITLE
Add array of active and standby temps to status reports

### DIFF
--- a/src/RepRap.cpp
+++ b/src/RepRap.cpp
@@ -1063,8 +1063,9 @@ OutputBuffer *RepRap::GetStatusResponse(uint8_t type, ResponseSource source)
 		const int8_t chamberHeater = (NumChamberHeaters > 0) ? heat->GetChamberHeater(0) : -1;
 		if (chamberHeater != -1)
 		{
-			response->catf("\"chamber\":{\"current\":%.1f,\"active\":%.1f,\"state\":%d,\"heater\":%d},",
+			response->catf("\"chamber\":{\"current\":%.1f,\"active\":%.1f,\"standby\":%.1f,\"state\":%d,\"heater\":%d},",
 				(double)heat->GetTemperature(chamberHeater), (double)heat->GetActiveTemperature(chamberHeater),
+				(double)heat->GetStandbyTemperature(chamberHeater),
 					heat->GetStatus(chamberHeater), chamberHeater);
 		}
 
@@ -1072,8 +1073,9 @@ OutputBuffer *RepRap::GetStatusResponse(uint8_t type, ResponseSource source)
 		const int8_t cabinetHeater = (NumChamberHeaters > 1) ? heat->GetChamberHeater(1) : -1;
 		if (cabinetHeater != -1)
 		{
-			response->catf("\"cabinet\":{\"current\":%.1f,\"active\":%.1f,\"state\":%d,\"heater\":%d},",
+			response->catf("\"cabinet\":{\"current\":%.1f,\"active\":%.1f,\"standby\":%.1f,\"state\":%d,\"heater\":%d},",
 				(double)heat->GetTemperature(cabinetHeater), (double)heat->GetActiveTemperature(cabinetHeater),
+				(double)heat->GetStandbyTemperature(cabinetHeater),
 					heat->GetStatus(cabinetHeater), cabinetHeater);
 		}
 
@@ -1085,6 +1087,26 @@ OutputBuffer *RepRap::GetStatusResponse(uint8_t type, ResponseSource source)
 		for (size_t heater = 0; heater < NumTotalHeaters; heater++)
 		{
 			response->catf("%c%.1f", ch, (double)heat->GetTemperature(heater));
+			ch = ',';
+		}
+		response->cat((ch == '[') ? "[]" : "]");
+
+		// Current temperatures
+		response->cat(",\"active\":");
+		ch = '[';
+		for (size_t heater = 0; heater < NumTotalHeaters; heater++)
+		{
+			response->catf("%c%.1f", ch, (double)heat->GetActiveTemperature(heater));
+			ch = ',';
+		}
+		response->cat((ch == '[') ? "[]" : "]");
+
+		// Current temperatures
+		response->cat(",\"standby\":");
+		ch = '[';
+		for (size_t heater = 0; heater < NumTotalHeaters; heater++)
+		{
+			response->catf("%c%.1f", ch, (double)heat->GetStandbyTemperature(heater));
 			ch = ',';
 		}
 		response->cat((ch == '[') ? "[]" : "]");


### PR DESCRIPTION
In addition to current temnperatures, the temps object now
contains an array of active temps and an array of standby
temps indexed by global heater number.

Since standby temp was just added to the bed object the standby
temps were also added to both the chamber and cabinet objects for
completeness.