### PR TITLE
M308: Generic Heater Control

### DIFF
--- a/src/GCodes/GCodes2.cpp
+++ b/src/GCodes/GCodes2.cpp
@@ -2417,6 +2417,109 @@ bool GCodes::HandleMcode(GCodeBuffer& gb, const StringRef& reply)
 		result = SetHeaterModel(gb, reply);
 		break;
 
+	case 308: // Set generic heater state
+	{
+		/*
+		 * M308 Generic Heater Control
+		 * 	Pnnn Heater number
+		 * 	Snnn Active Temp
+		 * 	Rnnn Standby Temp
+		 * 	Tnnn State: 0 = off, 1 = standby 2 = on.
+		 */
+		Heat& heat = reprap.GetHeat();
+		bool seen = false;
+		uint8_t currentHeater = 0;
+
+		if (gb.Seen('P')) {
+			currentHeater = gb.GetUIValue();
+			if (currentHeater >= NumTotalHeaters)
+			{
+				reply.printf("Invalid heater index '%d'", currentHeater);
+				result = GCodeResult::error;
+				break;
+			}
+		} else {
+			reply.copy("P parameter must be specified");
+			result = GCodeResult::error;
+			break;
+		}
+
+		const Heat::HeaterStatus currentHeaterStatus = heat.GetStatus(currentHeater);
+		if (currentHeaterStatus > Heat::HS_active) {
+			reply.printf("Heater is currently in %s state",
+				heat.HeaterStatusToString(currentHeaterStatus));
+			result = GCodeResult::error;
+			break;
+		}
+
+		Tool* tool = reprap.GetCurrentTool();
+		ToolState toolState = tool->GetState();
+		int toolHeater = tool->GetHeaterAssignedToTool(currentHeater);
+
+		// Active temperature
+		if (gb.Seen('S'))
+		{
+			seen = true;
+			if (toolHeater >= 0) {
+				tool->SetToolHeaterActiveTemperature(toolHeater, gb.GetFValue());
+			} else {
+				heat.SetActiveTemperature(currentHeater, gb.GetFValue());
+			}
+		}
+
+		if (gb.Seen('R'))
+		{
+			seen = true;
+			if (toolHeater >= 0) {
+				tool->SetToolHeaterStandbyTemperature(toolHeater, gb.GetFValue());
+			} else {
+				heat.SetStandbyTemperature(currentHeater, gb.GetFValue());
+			}
+		}
+
+		if (gb.Seen('T'))
+		{
+			seen = true;
+			const int8_t state = gb.GetIValue();
+			if (state < Heat::HS_off || state > Heat::HS_active) {
+				reply.copy("T parameter must be 0(off), 1(standby) or 2(active)");
+				result = GCodeResult::error;
+				break;
+			}
+
+			if ((reprap.GetPrintMonitor().IsPrinting() || IsPausing() || IsPaused() || IsResuming())
+				&& toolState == ToolState::active && toolHeater >= 0) {
+				reply.printf("The state of active tool %d can't be changed while printing, pausing or resuming",
+					tool->Number());
+				result = GCodeResult::error;
+				break;
+			}
+
+			switch(state) {
+			case Heat::HS_off:
+				heat.SwitchOff(currentHeater);
+				break;
+			case Heat::HS_standby:
+				heat.Standby(currentHeater, nullptr);
+				break;
+			case Heat::HS_active:
+				heat.Activate(currentHeater);
+				break;
+			}
+		}
+
+		if (!seen)
+		{
+			reply.printf("Heater %d State: '%s', Active temp: %.1f" DEGREE_SYMBOL \
+				", Standby temp: %.1f" DEGREE_SYMBOL ", Current temp: %.1f" DEGREE_SYMBOL,
+				currentHeater, heat.HeaterStatusToString(currentHeaterStatus),
+				(double)heat.GetActiveTemperature(currentHeater),
+				(double)heat.GetStandbyTemperature(currentHeater),
+				(double)heat.GetTemperature(currentHeater));
+		}
+	}
+	break;
+
 	case 350: // Set/report microstepping
 		{
 			bool interp = (gb.Seen('I') && gb.GetIValue() > 0);

--- a/src/Heating/Heat.cpp
+++ b/src/Heating/Heat.cpp
@@ -759,4 +759,22 @@ bool Heat::WriteBedAndChamberTempSettings(FileStore *f) const
 	return (buf.strlen() == 0) || f->Write(buf.c_str());
 }
 
+const char *Heat::HeaterStatusToString(HeaterStatus status) const
+{
+	switch(status) {
+	case HeaterStatus::HS_off:
+		return "Off";
+	case HeaterStatus::HS_standby:
+		return "Standby";
+	case HeaterStatus::HS_active:
+		return "Active";
+	case HeaterStatus::HS_fault:
+		return "Fault";
+	case HeaterStatus::HS_tuning:
+		return "Tuning";
+	default:
+		return "unknown";
+	}
+}
+
 // End

--- a/src/Heating/Heat.h
+++ b/src/Heating/Heat.h
@@ -149,6 +149,8 @@ public:
 
 	void SuspendHeaters(bool sus);								// Suspend the heaters to conserve power
 
+	const char *HeaterStatusToString(HeaterStatus status) const;
+
 private:
 	Heat(const Heat&);											// Private copy constructor to prevent copying
 

--- a/src/Tools/Tool.cpp
+++ b/src/Tools/Tool.cpp
@@ -517,4 +517,17 @@ bool Tool::UsesHeater(int8_t heater) const
 	return false;
 }
 
+int Tool::GetHeaterAssignedToTool(int8_t global_heater) const
+{
+	for (size_t i = 0; i < heaterCount; i++)
+	{
+		if (heaters[i] == global_heater)
+		{
+			return i;
+		}
+	}
+
+	return -1;
+}
+
 // End

--- a/src/Tools/Tool.h
+++ b/src/Tools/Tool.h
@@ -82,6 +82,8 @@ public:
 	void IterateExtruders(std::function<void(unsigned int)> f) const;
 	void IterateHeaters(std::function<void(int)> f) const;
 
+	int GetHeaterAssignedToTool(int8_t global_heater) const;
+
 	friend class RepRap;
 
 protected:


### PR DESCRIPTION
Parameters:

 * Pnnn Heater index
 * Snnn Target active temperature  (note 1)
 * Rnnn Target standby temperature  (note 1)
 * Tnnn Heater state: 0 = off, 1 = standby 2 = on. (notes 1,2)

This command allows direct control of heaters without having
to know whether a heater is a bed, chamber, tool or some other
type of heater.  It does not replace any existing G or M code
commands and is meant more for use from the command line and
by user interfaces.  Although nothing prevents it, this command
should not be used by slicers. They should continue to use the
standard control commands.

The P parameter is required and selects the heater.  There is no
default so the minimum command is M308 Pnnn which prints the
heater's current state, target active temperature, target standby
temperature and the current temperature as follows:

"Heater 1 State: 'Off', Active temp: 225.0°, Standby temp: 190.0°,
Current temp: 23.2°"

The S and R parameters are optional and set the target active and
standby temperatures.

The T parameter is also optional and if supplied, sets the heater's
current state where 0 = off, 1 = standby 2 = on.

Examples:
 * M308 P0 S70 R50
   Set heater 0 (usually but not necessarily the bed) target
   active temperature to 70 and the target standby temperature
   to 50.  Since the T parameter is not supplied, the heater's
   current state is not altered.

 * M308 P0 T1
   Set heater 0 to standby.  Any previously set standby temperature
   is preserved, even if set by another command such as M140, M141,
   G10, etc.

 * M308 P1 S225
   Set heater 1 (an extruder maybe) target active temperature to
   225 leaving its target standby temperature and state alone.

Notes:
(1): Since the T parameter explicitly controls the state of the
     heater, no special importance is placed on temperatures less
     than -273.  They will NOT turn the heater off as they may in
     other commands.

(2): This command will return an error if an attempt is made
     to set the temperatures or state of a heater in "fault"
     or "tuning" state.  Use the appropriate commands to return
     the heater to a working state before re-issuing this command.

Special considerations when a heater is assigned to a tool:

Attempting to change the state of a heater that is assigned to
the current tool when the printer is in the Printing, Pausing,
Paused or Resuming state will result in an error.  This is to
prevent an accidental disruption of a print.

Changing the temperatures of a heater assigned to a tool will also
change the tool's defined active and standby temperatures.