### PR TITLE
FtpResponder:  Initialize haveCompleteLine to false

### DIFF
--- a/src/Networking/FtpResponder.h
+++ b/src/Networking/FtpResponder.h
@@ -45,7 +45,7 @@ protected:
 
 	void CloseDataPort();
 
-	bool haveCompleteLine;
+	bool haveCompleteLine = false;
 	bool haveFileToMove;
 	char clientMessage[ftpMessageLength];
 	size_t clientPointer;


### PR DESCRIPTION
When an FtpResponder starts, the clientMessage buffer has junk in it
as does haveCompleteLine, which is interpreted as 'true'.
When the first client connects, the state machine thinks it has
a completed line and calls ProcessLine which fails immediately
with "500 Unknown login command".  This confuses some clients to no
end and they can either hang or report an error or both.  The state
machine self corrects but by then it's too late.

Now in FtpResponder.h, we initialize haveCompletedLine to 'false'
so we don't attempt to call ProcessLine the first time a responder
gets a connect.