### PR TITLE
Add M500 P10 to enable saving of manually entered tool offsets

### DIFF
--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -3925,14 +3925,38 @@ GCodeResult GCodes::WriteConfigOverrideFile(GCodeBuffer& gb, const StringRef& re
 		ok = reprap.GetHeat().WriteModelParameters(f);
 	}
 
+	// M500 can have a Pnn:nn parameter to enable extra data being saved
+	// P10 will enable saving of tool offsets even if they have not been determined via M585
+	bool p10 = false;
+
+	// P31 will include G31 Z probe value
+	bool p31 = false;
+	if (gb.Seen('P'))
+	{
+		uint32_t pVals[2];
+		size_t pCount = 2;
+		gb.GetUnsignedArray(pVals, pCount, false);
+		for (size_t i = 0; i < pCount; i++)
+		{
+			switch (pVals[i])
+			{
+				case 10:
+					p10 = true;
+					break;
+				case 31:
+					p31 = true;
+					break;
+			}
+		}
+	}
 	if (ok)
 	{
-		ok = platform.WritePlatformParameters(f, gb.Seen('P') && gb.GetIValue() == 31);
+		ok = platform.WritePlatformParameters(f, p31);
 	}
 
 	if (ok)
 	{
-		ok = reprap.WriteToolParameters(f);
+		ok = reprap.WriteToolParameters(f, p10);
 	}
 
 #if SUPPORT_WORKPLACE_COORDINATES

--- a/src/RepRap.cpp
+++ b/src/RepRap.cpp
@@ -2320,14 +2320,14 @@ bool RepRap::WriteToolSettings(FileStore *f) const
 }
 
 // Save some information in config-override.g
-bool RepRap::WriteToolParameters(FileStore *f) const
+bool RepRap::WriteToolParameters(FileStore *f, const bool forceWriteOffsets) const
 {
 	bool ok = true, written = false;
 	MutexLocker lock(toolListMutex);
 	for (const Tool *t = toolList; ok && t != nullptr; t = t->Next())
 	{
 		const AxesBitmap axesProbed = t->GetAxisOffsetsProbed();
-		if (axesProbed != 0)
+		if (axesProbed != 0 || forceWriteOffsets)
 		{
 			String<ScratchStringLength> scratchString;
 			if (!written)
@@ -2338,7 +2338,7 @@ bool RepRap::WriteToolParameters(FileStore *f) const
 			scratchString.catf("G10 P%d", t->Number());
 			for (size_t axis = 0; axis < MaxAxes; ++axis)
 			{
-				if (IsBitSet(axesProbed, axis))
+				if (forceWriteOffsets || IsBitSet(axesProbed, axis))
 				{
 					scratchString.catf(" %c%.2f", gCodes->GetAxisLetters()[axis], (double)(t->GetOffset(axis)));
 				}

--- a/src/RepRap.h
+++ b/src/RepRap.h
@@ -142,7 +142,7 @@ public:
 
 #if HAS_MASS_STORAGE
 	bool WriteToolSettings(FileStore *f) const;				// save some information for the resume file
-	bool WriteToolParameters(FileStore *f) const;			// save some information in config-override.g
+	bool WriteToolParameters(FileStore *f, const bool forceWriteOffsets) const;			// save some information in config-override.g
 #endif
 
 	void ReportInternalError(const char *file, const char *func, int line) const;	// Report an internal error


### PR DESCRIPTION
Also extend M500 P parameter to take multiple values separated by colon.