### PR TITLE
Fix nullptr dereference when default probe is not defined

### DIFF
--- a/src/GCodes/GCodes3.cpp
+++ b/src/GCodes/GCodes3.cpp
@@ -761,15 +761,13 @@ GCodeResult GCodes::StraightProbe(GCodeBuffer& gb, const StringRef& reply)
 	sps.SetTarget(target);
 
 	// See whether we are using a user-defined Z probe or just current one
-	size_t probeToUse = platform.GetEndstops().GetCurrentZProbeNumber();
-	if (gb.Seen('P'))
+	const size_t probeToUse = gb.Seen('P') ? gb.GetUIValue() : platform.GetEndstops().GetCurrentZProbeNumber();
+
+	// Check if this probe exists to not run into a nullptr dereference later
+	if (platform.GetEndstops().GetZProbe(probeToUse) == nullptr)
 	{
-		probeToUse = gb.GetUIValue();
-		if (platform.GetEndstops().GetZProbe(probeToUse) == nullptr)
-		{
-			reply.copy("Invalid probe number");
-			return GCodeResult::error;
-		}
+		reply.catf("Invalid probe number: %d", probeToUse);
+		return GCodeResult::error;
 	}
 	sps.SetZProbeToUse(probeToUse);
 

--- a/src/Movement/StraightProbeSettings.h
+++ b/src/Movement/StraightProbeSettings.h
@@ -40,7 +40,7 @@ public:
 	void AddMovingAxis(const size_t);
 
 	const size_t GetZProbeToUse() const { return probeToUse; }
-	void SetZProbeToUse(size_t probeNumber) { probeToUse = probeNumber; }
+	void SetZProbeToUse(const size_t probeNumber) { probeToUse = probeNumber; }
 
 	const bool ProbingAway() const;
 	const bool SignalError() const;


### PR DESCRIPTION
If the default probe is not defined and there is no `Pnnn` given to `G38.x` then this would lead to a `nullptr` dereference later.