### PR TITLE
LocalHeater.cpp: Add expected and actual temps to fault msg

### DIFF
--- a/src/Heating/LocalHeater.cpp
+++ b/src/Heating/LocalHeater.cpp
@@ -288,8 +288,8 @@ void LocalHeater::Spin() noexcept
 					++heatingFaultCount;
 					if (heatingFaultCount * HeatSampleIntervalMillis > GetMaxHeatingFaultTime() * SecondsToMillis)
 					{
-						RaiseHeaterFault("Heating fault on heater %u, temperature excursion exceeded %.1f" DEGREE_SYMBOL "C\n",
-											GetHeaterNumber(), (double)GetMaxTemperatureExcursion());
+						RaiseHeaterFault("Heating fault on heater %u, temperature excursion exceeded %.1f" DEGREE_SYMBOL "C.  Expected: %.1f" DEGREE_SYMBOL "C.  Actual: %.1f" DEGREE_SYMBOL "C.\n",
+											GetHeaterNumber(), (double)GetMaxTemperatureExcursion(), (double)targetTemperature, (double)temperature);
 					}
 				}
 				else if (heatingFaultCount != 0)


### PR DESCRIPTION
https://forum.duet3d.com/topic/15276/proposed-change-to-heater-excursion-message

The temperature excursion message now looks something like:

"Heating fault on heater 1, temperature excursion exceeded
 15°C.  Expected: 225°C.  Actual: 209°C"