### PR TITLE
Allow Chip-Select Pins to Be Used by More than One Sensor.

### DIFF
--- a/src/Hardware/IoPorts.cpp
+++ b/src/Hardware/IoPorts.cpp
@@ -248,7 +248,8 @@ bool IoPort::Allocate(const char *pn, const StringRef& reply, PinUsedBy neededFo
 		}
 		logicalPin = lp;
 		hardwareInvert = hwInvert;
-		if (neededFor == PinUsedBy::temporaryInput || neededFor == PinUsedBy::chipSelect){
+		if (neededFor == PinUsedBy::temporaryInput || neededFor == PinUsedBy::chipSelect)
+		{
 			isSharedInput = true;
 		}
 		else

--- a/src/Hardware/IoPorts.cpp
+++ b/src/Hardware/IoPorts.cpp
@@ -230,7 +230,7 @@ bool IoPort::Allocate(const char *pn, const StringRef& reply, PinUsedBy neededFo
 	if (lp != NoLogicalPin)					// if not assigning "nil"
 	{
 		bool doSetMode = true;
-		if (portUsedBy[lp] == PinUsedBy::unused || (portUsedBy[lp] == PinUsedBy::temporaryInput && neededFor != PinUsedBy::temporaryInput))
+		if (portUsedBy[lp] == PinUsedBy::unused || (portUsedBy[lp] == PinUsedBy::temporaryInput && neededFor != PinUsedBy::temporaryInput) || (portUsedBy[lp] == PinUsedBy::chipSelect && neededFor == PinUsedBy::chipSelect))
 		{
 			portUsedBy[lp] = neededFor;
 		}
@@ -248,7 +248,13 @@ bool IoPort::Allocate(const char *pn, const StringRef& reply, PinUsedBy neededFo
 		}
 		logicalPin = lp;
 		hardwareInvert = hwInvert;
-		isSharedInput = (neededFor == PinUsedBy::temporaryInput);
+		if (neededFor == PinUsedBy::temporaryInput || neededFor == PinUsedBy::chipSelect){
+			isSharedInput = true;
+		}
+		else
+		{
+			isSharedInput = false;
+		}
 		SetInvert(inverted);
 
 		if (doSetMode && !SetMode(access))

--- a/src/Heating/Sensors/CurrentLoopTemperatureSensor.cpp
+++ b/src/Heating/Sensors/CurrentLoopTemperatureSensor.cpp
@@ -69,7 +69,8 @@ GCodeResult CurrentLoopTemperatureSensor::Configure(GCodeBuffer& gb, const Strin
 	{
 		CopyBasicDetails(reply);
 		reply.catf(", channel: %d", (int)chipChannel);
-		if (isDifferential){
+		if (isDifferential)
+		{
 			reply.copy(", differential mode");
 		}
 		reply.catf(", temperature range %.1f to %.1fC", (double)tempAt4mA, (double)tempAt20mA);

--- a/src/Heating/Sensors/CurrentLoopTemperatureSensor.cpp
+++ b/src/Heating/Sensors/CurrentLoopTemperatureSensor.cpp
@@ -73,7 +73,7 @@ GCodeResult CurrentLoopTemperatureSensor::Configure(GCodeBuffer& gb, const Strin
 		{
 			reply.copy(", differential mode");
 		}
-		reply.catf(", temperature range %.1f to %.1fC", (double)tempAt4mA, (double)tempAt20mA);
+		reply.catf(", temperature range %.1f to %.1fC", (double)minLinearAdcTemp, (double)tempAt20mA);
 	}
 	return GCodeResult::ok;
 }

--- a/src/Heating/Sensors/CurrentLoopTemperatureSensor.cpp
+++ b/src/Heating/Sensors/CurrentLoopTemperatureSensor.cpp
@@ -68,6 +68,10 @@ GCodeResult CurrentLoopTemperatureSensor::Configure(GCodeBuffer& gb, const Strin
 	else
 	{
 		CopyBasicDetails(reply);
+		reply.catf(", channel: %d", (int)chipChannel);
+		if (isDifferential){
+			reply.copy(", differential mode");
+		}
 		reply.catf(", temperature range %.1f to %.1fC", (double)tempAt4mA, (double)tempAt20mA);
 	}
 	return GCodeResult::ok;

--- a/src/Heating/Sensors/SensorWithPort.cpp
+++ b/src/Heating/Sensors/SensorWithPort.cpp
@@ -19,12 +19,11 @@ SensorWithPort::~SensorWithPort() noexcept
 }
 
 // Try to configure the port. Return true if the port is valid at the end, else return false and set the error message in 'reply'. Set 'seen' if we saw the P parameter.
-bool SensorWithPort::ConfigurePort(GCodeBuffer& gb, const StringRef& reply, PinAccess access, bool& seen)
+bool SensorWithPort::ConfigurePort(GCodeBuffer& gb, const StringRef& reply, PinAccess access, PinUsedBy usedBy, bool& seen)
 {
-	if (gb.Seen('P'))
-	{
+	if (gb.Seen('P')) {
 		seen = true;
-		return port.AssignPort(gb, reply, PinUsedBy::sensor, access);
+		return port.AssignPort(gb, reply, usedBy, access);
 	}
 	if (port.IsValid())
 	{
@@ -32,6 +31,11 @@ bool SensorWithPort::ConfigurePort(GCodeBuffer& gb, const StringRef& reply, PinA
 	}
 	reply.copy("Missing port name parameter");
 	return false;
+}
+
+bool SensorWithPort::ConfigurePort(GCodeBuffer& gb, const StringRef& reply, PinAccess access, bool& seen)
+{
+	return ConfigurePort(gb, reply, access, PinUsedBy::sensor, seen);
 }
 
 // Copy the basic details to the reply buffer. This hides the version in the base class.

--- a/src/Heating/Sensors/SensorWithPort.cpp
+++ b/src/Heating/Sensors/SensorWithPort.cpp
@@ -21,7 +21,8 @@ SensorWithPort::~SensorWithPort() noexcept
 // Try to configure the port. Return true if the port is valid at the end, else return false and set the error message in 'reply'. Set 'seen' if we saw the P parameter.
 bool SensorWithPort::ConfigurePort(GCodeBuffer& gb, const StringRef& reply, PinAccess access, PinUsedBy usedBy, bool& seen)
 {
-	if (gb.Seen('P')) {
+	if (gb.Seen('P'))
+	{
 		seen = true;
 		return port.AssignPort(gb, reply, usedBy, access);
 	}

--- a/src/Heating/Sensors/SensorWithPort.h
+++ b/src/Heating/Sensors/SensorWithPort.h
@@ -17,6 +17,7 @@ protected:
 	~SensorWithPort() noexcept;
 
 	// Try to configure the port
+	bool ConfigurePort(GCodeBuffer& gb, const StringRef& reply, PinAccess access, PinUsedBy usedBy, bool& seen);
 	bool ConfigurePort(GCodeBuffer& gb, const StringRef& reply, PinAccess access, bool& seen);
 
 	// Copy the basic details to the reply buffer. This hides the version in the base class.

--- a/src/Heating/Sensors/SpiTemperatureSensor.cpp
+++ b/src/Heating/Sensors/SpiTemperatureSensor.cpp
@@ -24,7 +24,7 @@ SpiTemperatureSensor::SpiTemperatureSensor(unsigned int sensorNum, const char *n
 
 bool SpiTemperatureSensor::ConfigurePort(GCodeBuffer& gb, const StringRef& reply, bool& seen)
 {
-	const bool ret = SensorWithPort::ConfigurePort(gb, reply, PinAccess::write1, seen);
+	const bool ret = SensorWithPort::ConfigurePort(gb, reply, PinAccess::write1, PinUsedBy::chipSelect, seen);
 	device.csPin = port.GetPin();
 	return ret;
 }

--- a/src/RepRapFirmware.h
+++ b/src/RepRapFirmware.h
@@ -92,7 +92,8 @@ enum class PinUsedBy : uint8_t
 	gpout,
 	filamentMonitor,
 	temporaryInput,
-	sensor
+	sensor,
+	chipSelect
 };
 
 #include "Configuration.h"


### PR DESCRIPTION
This is a complement to https://github.com/dc42/RepRapFirmware/commit/98740f128d4e9fd152f107b0b8ac4e2dd29c8b2e

This change creates a pin type of "chipSelect" which allows the chip-select pins to be shared among temperature sensors, where 1 single SPI chip can provide many distinct readings. At current time, this only applies to the CurrentLoopTemperatureSensor, however it will be useful in the future should other SPI chips be implemented that are capable of inputting multiple temperature probes.

Code will prevent the accidental re-use of chip-select pins between GPIO. Once assigned as a chip-select, it cannot be used as GPIO and vice-versa to prevent configuration errors.