### PR TITLE
Fixes for Hangprinter's forward kinematics

### DIFF
--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -23,7 +23,6 @@ public:
 	void MotorStepsToCartesian(const int32_t motorPos[], const float stepsPerMm[], size_t numVisibleAxes, size_t numTotalAxes, float machinePos[]) const noexcept override;
 	bool SupportsAutoCalibration() const noexcept override { return true; }
 	bool IsReachable(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept override;
-	bool DoAutoCalibration(size_t numFactors, const RandomProbePointSet& probePoints, const StringRef& reply) noexcept override;
 	void SetCalibrationDefaults() noexcept override { Init(); }
 #if HAS_MASS_STORAGE || HAS_LINUX_INTERFACE
 	bool WriteCalibrationParameters(FileStore *f) const noexcept override;
@@ -62,11 +61,9 @@ private:
 	void Init() noexcept;
 	void Recalc() noexcept;
 	float LineLengthSquared(const float machinePos[3], const float anchor[3]) const noexcept;		// Calculate the square of the line length from a spool from a Cartesian coordinate
-	void InverseTransform(float La, float Lb, float Lc, float machinePos[3]) const noexcept;
+	void ForwardTransform(float a, float b, float c, float d, float machinePos[3]) const noexcept;
 	float MotorPosToLinePos(const int32_t motorPos, size_t axis) const noexcept;
 
-	floatc_t ComputeDerivative(unsigned int deriv, float La, float Lb, float Lc) const noexcept;	// Compute the derivative of height with respect to a parameter at a set of motor endpoints
-	void Adjust(size_t numFactors, const floatc_t v[]) noexcept;									// Perform 3-, 6- or 9-factor adjustment
 	void PrintParameters(const StringRef& reply) const noexcept;									// Print all the parameters for debugging
 
 	float anchors[HANGPRINTER_AXES][3];				// XYZ coordinates of the anchors
@@ -80,13 +77,6 @@ private:
 	// Derived parameters
 	float k0[HANGPRINTER_AXES], spoolRadiiSq[HANGPRINTER_AXES], k2[HANGPRINTER_AXES], lineLengthsOrigin[HANGPRINTER_AXES];
 	float printRadiusSquared;
-	float Da2, Db2, Dc2;
-	float Xab, Xbc, Xca;
-	float Yab, Ybc, Yca;
-	float Zab, Zbc, Zca;
-	float P, Q, R, P2, U, A;
-
-	bool doneAutoCalibration;							// True if we have done auto calibration
 
 #if DUAL_CAN
 	// Some CAN helpers


### PR DESCRIPTION
## What did I do?
Two G1 H2 moves with my Hangprinter via the web GUI.
These two:
```
G1 H2 X1
G1 H2 X-1
```

## What did you expect to happen?
Motor move back and forth.
No change in tool position in web GUI,
or maybe a temporary change that would cancel out after the second move, like this (case 1):
(0, 0, 0) -> (-0.1, 0.6, 0.25) -> (0, 0, 0)
or preferably like this (case 2):
(0, 0, 0) -> (0, 0, 0) -> (0, 0, 0)

## What happened instead?
Motor moved alright (probably a few microns off, didn't measure).
But the tool position in the web GUI was changed like this:
(0, 0, 0) -> ( -2.14467, 10.7087, -273.999) -> ( -0.0738422, 0.479912, -125.36 )

It turned out Hangprinter's forward kinematics functions were called after each G1 H2 move,
and they were wrong.

## What did you do?
Hangprinter wants `machinePos[]` and `motorPos[]` to be unaffected by G1 H2 moves, shown as case 2 above.

However, that wasn't possible without going outside of HangprinterKinematics.cpp, which I didn't want to do.
So I wrote a new forward kinematics to satisfy case 1 instead.

Case 2 will be fulfilled by a macro instead.

I removed all code that used the old forward kinematics.