### PR TITLE
Don't fill buffer when flushing CAN receive hw

### DIFF
--- a/src/CAN/CanInterface.cpp
+++ b/src/CAN/CanInterface.cpp
@@ -815,9 +815,9 @@ uint32_t CanInterface::SendPlainMessageNoFree(CanMessageBuffer *buf, uint32_t co
 	return (can1dev != nullptr) ? can1dev->SendMessage(CanDevice::TxBufferNumber::fifo, timeout, buf) : 0;
 }
 
-bool CanInterface::ReceivePlainMessage(CanMessageBuffer *buf, uint32_t const timeout, bool fillBuf) noexcept
+bool CanInterface::ReceivePlainMessage(CanMessageBuffer *buf, uint32_t const timeout) noexcept
 {
-	return can1dev != nullptr && can1dev->ReceiveMessage(CanDevice::RxBufferNumber::fifo0, timeout, buf, fillBuf);
+	return can1dev != nullptr && can1dev->ReceiveMessage(CanDevice::RxBufferNumber::fifo0, timeout, buf);
 }
 
 #endif
@@ -1480,7 +1480,7 @@ CanMessageBuffer * CanInterface::ODrive::PrepareSimpleMessage(DriverId const dri
 	// Find the correct arbitration id
 
  	// Flush CAN receive hardware
-	while (CanInterface::ReceivePlainMessage(buf , 0, false)) { }
+	while (CanInterface::ReceivePlainMessage(nullptr, 0)) { }
 
 	// Build the message
 	buf->id = ArbitrationId(driver, cmd);

--- a/src/CAN/CanInterface.cpp
+++ b/src/CAN/CanInterface.cpp
@@ -815,9 +815,9 @@ uint32_t CanInterface::SendPlainMessageNoFree(CanMessageBuffer *buf, uint32_t co
 	return (can1dev != nullptr) ? can1dev->SendMessage(CanDevice::TxBufferNumber::fifo, timeout, buf) : 0;
 }
 
-bool CanInterface::ReceivePlainMessage(CanMessageBuffer *buf, uint32_t const timeout) noexcept
+bool CanInterface::ReceivePlainMessage(CanMessageBuffer *buf, uint32_t const timeout, bool fillBuf) noexcept
 {
-	return can1dev != nullptr && can1dev->ReceiveMessage(CanDevice::RxBufferNumber::fifo0, timeout, buf);
+	return can1dev != nullptr && can1dev->ReceiveMessage(CanDevice::RxBufferNumber::fifo0, timeout, buf, fillBuf);
 }
 
 #endif
@@ -1480,7 +1480,7 @@ CanMessageBuffer * CanInterface::ODrive::PrepareSimpleMessage(DriverId const dri
 	// Find the correct arbitration id
 
  	// Flush CAN receive hardware
-	while (CanInterface::ReceivePlainMessage(buf , 0)) { }
+	while (CanInterface::ReceivePlainMessage(buf , 0, false)) { }
 
 	// Build the message
 	buf->id = ArbitrationId(driver, cmd);

--- a/src/CAN/CanInterface.h
+++ b/src/CAN/CanInterface.h
@@ -88,7 +88,7 @@ namespace CanInterface
 
 #if DUAL_CAN
 	uint32_t SendPlainMessageNoFree(CanMessageBuffer *buf, uint32_t timeout = UsualSendTimeout) noexcept;
-	bool ReceivePlainMessage(CanMessageBuffer *buf, uint32_t timeout = UsualResponseTimeout, bool fillBuf = true) noexcept;
+	bool ReceivePlainMessage(CanMessageBuffer *buf, uint32_t timeout = UsualResponseTimeout) noexcept;
 #endif
 
 #if !SAME70

--- a/src/CAN/CanInterface.h
+++ b/src/CAN/CanInterface.h
@@ -88,7 +88,7 @@ namespace CanInterface
 
 #if DUAL_CAN
 	uint32_t SendPlainMessageNoFree(CanMessageBuffer *buf, uint32_t timeout = UsualSendTimeout) noexcept;
-	bool ReceivePlainMessage(CanMessageBuffer *buf, uint32_t timeout = UsualResponseTimeout) noexcept;
+	bool ReceivePlainMessage(CanMessageBuffer *buf, uint32_t timeout = UsualResponseTimeout, bool fillBuf = true) noexcept;
 #endif
 
 #if !SAME70

--- a/src/CAN/CanInterface.h
+++ b/src/CAN/CanInterface.h
@@ -144,7 +144,8 @@ namespace CanInterface
 #if DUAL_CAN
 namespace ODrive {
 	CanId ArbitrationId(DriverId driver, uint8_t cmd) noexcept;
-	CanMessageBuffer * PrepareSimpleMessage(DriverId const driver, uint8_t const cmd, const StringRef& reply) noexcept;
+	CanMessageBuffer * PrepareSimpleMessage(DriverId const driver, const StringRef& reply) noexcept;
+	void FlushCanReceiveHardware() noexcept;
 	bool GetExpectedSimpleMessage(CanMessageBuffer *buf, DriverId const driver, uint8_t const cmd, const StringRef& reply) noexcept;
 }
 #endif


### PR DESCRIPTION
We need to flush CAN receive hw sometimes. We might not want to overwrite our buffer, or allocate a new throwaway one.

This was done to narrow down potential error sources in a debugging session involving sometimes failing ODrive CAN communication.

Also see https://github.com/Duet3D/CoreN2G/pull/1