### PR TITLE
Fixes resurrect.g bug for Hangprinter

### DIFF
--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -447,33 +447,40 @@ bool HangprinterKinematics::WriteCalibrationParameters(FileStore *f) const noexc
 	if (ok)
 	{
 		String<100> scratchString;
-		scratchString.printf("M669 K6 A%.3f:%.3f:%.3f B%.3f:%.3f:%.3f C%.3f:%.3f:%.3f D%.3f:%.3f:%.3f P%.1f\n",
+		scratchString.printf("M669 K6 A%.3f:%.3f:%.3f B%.3f:%.3f:%.3f",
 							(double)anchors[A_AXIS][X_AXIS], (double)anchors[A_AXIS][Y_AXIS], (double)anchors[A_AXIS][Z_AXIS],
-							(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS],
-							(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS],
-							(double)anchors[D_AXIS][X_AXIS], (double)anchors[D_AXIS][Y_AXIS], (double)anchors[D_AXIS][Z_AXIS],
-							(double)printRadius);
+							(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS]);
 		ok = f->Write(scratchString.c_str());
-		if (ok) {
-			scratchString.printf("M666 Q%.6f R%.3f:%.3f:%.3f:%.3f U%d:%d:%d:%d ",
-								(double)spoolBuildupFactor, (double)spoolRadii[A_AXIS],
-								(double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS],
-								(int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS],
-								(int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]
-					);
+		if (ok)
+		{
+			scratchString.printf(" C%.3f:%.3f:%.3f D%.3f:%.3f:%.3f P%.1f\n",
+								(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS],
+								(double)anchors[D_AXIS][X_AXIS], (double)anchors[D_AXIS][Y_AXIS], (double)anchors[D_AXIS][Z_AXIS],
+								(double)printRadius);
 			ok = f->Write(scratchString.c_str());
-			if (ok) {
-				scratchString.printf("O%d:%d:%d:%d L%d:%d:%d:%d H%d:%d:%d:%d J%d:%d:%d:%d\n",
-									(int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS],
-									(int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS],
-									(int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS],
-									(int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS],
-									(int)spoolGearTeeth[A_AXIS], (int)spoolGearTeeth[B_AXIS],
-									(int)spoolGearTeeth[C_AXIS], (int)spoolGearTeeth[D_AXIS],
-									(int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS],
-									(int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]
+			if (ok)
+			{
+				scratchString.printf("M666 Q%.6f R%.3f:%.3f:%.3f:%.3f U%d:%d:%d:%d",
+									(double)spoolBuildupFactor, (double)spoolRadii[A_AXIS],
+									(double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS],
+									(int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS],
+									(int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]
 						);
 				ok = f->Write(scratchString.c_str());
+				if (ok)
+				{
+					scratchString.printf(" O%d:%d:%d:%d L%d:%d:%d:%d H%d:%d:%d:%d J%d:%d:%d:%d\n",
+										(int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS],
+										(int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS],
+										(int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS],
+										(int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS],
+										(int)spoolGearTeeth[A_AXIS], (int)spoolGearTeeth[B_AXIS],
+										(int)spoolGearTeeth[C_AXIS], (int)spoolGearTeeth[D_AXIS],
+										(int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS],
+										(int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]
+							);
+					ok = f->Write(scratchString.c_str());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The scratch string was too short, so we missed the tail of the M669 command.