### PR TITLE
Adds line force readouts for Hangprinter ODrive

### DIFF
--- a/src/CAN/CanInterface.cpp
+++ b/src/CAN/CanInterface.cpp
@@ -990,6 +990,15 @@ pre(driver.IsRemote())
 			cons.PopulateFromCommand(gb);
 			return cons.SendAndGetResponse(CanMessageType::m569p7, driver.boardAddress, reply);
 		}
+#if DUAL_CAN
+	case 8:			// read axis force via secondary CAN
+		{
+			if (reprap.GetMove().GetKinematics().GetKinematicsType() == KinematicsType::hangprinter) {
+				return HangprinterKinematics::ReadODrive3AxisForce(driver, reply);
+			}
+			return GCodeResult::errorNotSupported;
+		}
+#endif
 
 	default:
 		return GCodeResult::errorNotSupported;

--- a/src/GCodes/GCodes3.cpp
+++ b/src/GCodes/GCodes3.cpp
@@ -1430,9 +1430,12 @@ GCodeResult GCodes::ConfigureLocalDriver(GCodeBuffer& gb, const StringRef& reply
 
 	case 1:
 	case 3:
+	case 4:
 	case 5:
 	case 6:
-		// Main board drivers do not support closed loop modes, or reading encoders
+	case 8:
+		// Main board drivers do not support closed loop modes, or reading encoders,
+		// or reading motor currents through the subfunction 8
 		reply.copy("Command is not supported on local drivers");
 		return GCodeResult::error;
 

--- a/src/GCodes/GCodes3.cpp
+++ b/src/GCodes/GCodes3.cpp
@@ -1381,15 +1381,15 @@ GCodeResult GCodes::ConfigureDriver(GCodeBuffer& gb, const StringRef& reply) THR
 	DriverId driverIds[drivesCount];
 	gb.GetDriverIdArray(driverIds, drivesCount);
 
-	bool const isEncoderReading = (gb.GetCommandFraction() == 3);
-	if (isEncoderReading)
+	bool const isSetOfReadings = (gb.GetCommandFraction() == 3 || gb.GetCommandFraction() == 8 );
+	if (isSetOfReadings)
 	{
 		reply.copy("[");
 	}
 
-	// Hangprinter needs M569 to support multiple P parameters in M569.3 and M569.4. This poses a problem for other uses of M569 because the output may be too long
+	// Hangprinter needs M569 to support multiple P parameters in M569.3, M569.4, and M569.8. This poses a problem for other uses of M569 because the output may be too long
 	// to fit in the reply buffer, and we can only use an OutputBuffer instead if the overall result is success.
-	// Therefore we only support multiple P parameters for subfunctions 3 and 4.
+	// Therefore we only support multiple P parameters for subfunctions 3, 4, and 8.
 	GCodeResult res = GCodeResult::ok;
 	for (size_t i = 0; i < drivesCount; ++i)
 	{
@@ -1401,13 +1401,13 @@ GCodeResult GCodes::ConfigureDriver(GCodeBuffer& gb, const StringRef& reply) THR
 					:
 #endif
 					ConfigureLocalDriver(gb, reply, id.localDriver);
-		if (res != GCodeResult::ok || (!isEncoderReading && gb.GetCommandFraction() != 4))
+		if (res != GCodeResult::ok || (!isSetOfReadings && gb.GetCommandFraction() != 4))
 		{
 			break;
 		}
 	}
 
-	if (isEncoderReading && res == GCodeResult::ok)
+	if (isSetOfReadings && res == GCodeResult::ok)
 	{
 		reply.cat(" ],\n");
 	}

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -41,8 +41,15 @@ public:
 	bool WriteResumeSettings(FileStore *f) const noexcept override;
 #endif
 #if DUAL_CAN
+	static GCodeResult ReadODrive3AxisForce(DriverId driver, const StringRef& reply,
+																					float setTorqueConstants[] = nullptr, uint32_t setMechanicalAdvantage[] = nullptr,
+																					uint32_t setSpoolGearTeeth[] = nullptr, uint32_t setMotorGearTeeth[] = nullptr,
+																					float setSpoolRadii[] = nullptr) THROWS(GCodeException);
 	static GCodeResult ReadODrive3Encoder(DriverId driver, GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeException);
-	static GCodeResult SetODrive3TorqueMode(DriverId driver, float torque, const StringRef& reply) noexcept;
+	static GCodeResult SetODrive3TorqueMode(DriverId driver, float force_Newton, const StringRef& reply,
+																					uint32_t setMechanicalAdvantage[] = nullptr,
+																					uint32_t setSpoolGearTeeth[] = nullptr, uint32_t setMotorGearTeeth[] = nullptr,
+																					float setSpoolRadii[] = nullptr) noexcept;
 #endif
 
 protected:
@@ -91,6 +98,7 @@ private:
 	float maxPlannedForce_Newton[HANGPRINTER_AXES] = { 0.0F };
 	float guyWireLengths[HANGPRINTER_AXES] = { 0.0F };
 	float targetForce_Newton = 0.0F;
+	float torqueConstants[HANGPRINTER_AXES] = { 0.0F };
 
 	// Derived parameters
 	float k0[HANGPRINTER_AXES] = { 0.0F };
@@ -111,8 +119,9 @@ private:
 		bool valid = false;
 		float value = 0.0;
 	};
+	static ODriveAnswer GetODrive3MotorCurrent(DriverId driver, const StringRef& reply) THROWS(GCodeException);
 	static ODriveAnswer GetODrive3EncoderEstimate(DriverId driver, bool makeReference, const StringRef& reply, bool subtractReference) THROWS(GCodeException);
-	static GCodeResult SetODrive3TorqueModeInner(DriverId driver, float torque, const StringRef& reply) noexcept;
+	static GCodeResult SetODrive3TorqueModeInner(DriverId driver, float torque_Nm, const StringRef& reply) noexcept;
 	static GCodeResult SetODrive3PosMode(DriverId driver, const StringRef& reply) noexcept;
 #endif
 };


### PR DESCRIPTION
... And also changes units when setting torque mode, from Nm to N.

These readouts can be useful for detecting slack lines or over
tight lines during print or calibration.
They can also enable automatic homing, since homing a Hangprinter
includes setting the correct pre-tension.

The change of units when setting torque mode is to be consistent
across interfaces. Newtons of force are also much easier to
understand and harder to mis-type.

New usable torque mode values are in the range ~10,
instead of around ~0.05 like we had before, which invited the
typos "0.5" and "5.0", who could both create dangerous situations.