### PR TITLE
Add slicerBased time estimate to Menu system

### DIFF
--- a/src/Display/MenuItem.cpp
+++ b/src/Display/MenuItem.cpp
@@ -441,7 +441,13 @@ void ValueMenuItem::Draw(Lcd& lcd, PixelNumber rightMargin, bool highlight, Pixe
 				case 39:	// top speed
 					currentValue.f = reprap.GetMove().GetTopSpeedMmPerSec();
 					break;
-
+				case 40:       // Print time remaining, slicer-based
+					currentValue u = (reprap.GetPrintMonitor().IsPrinting()) ? 
+										? static_cast<int>(reprap.GetPrintMonitor().EstimateTimeLeft(PrintEstimationMethod::slicerBased))
+											: 0;
+					currentFormat = PrintFormat::asTime;
+					break; 
+			                
 				default:
 					error = true;
 				}


### PR DESCRIPTION
Add `N540` as slicer based time estimate for menu system. Would have preferred to be continuous with 536 and 537, but 538 and 539 are already taken.