### PR TITLE
Adds flex compensation to Hangprinter forward transform

### DIFF
--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -106,12 +106,15 @@ private:
 	float k2[HANGPRINTER_AXES] = { 0.0F };
 	float distancesOrigin[HANGPRINTER_AXES] = { 0.0F };
 	float springKsOrigin[HANGPRINTER_AXES] = { 0.0F };
-	float distancesWithRelaxedSpringsOrigin[HANGPRINTER_AXES] = { 0.0F };
+	float relaxedSpringLengthsOrigin[HANGPRINTER_AXES] = { 0.0F };
 	float fOrigin[HANGPRINTER_AXES] = { 0.0F };
 	float printRadiusSquared = 0.0F;
 
 	float SpringK(float const springLength) const noexcept;
 	void StaticForces(float const machinePos[3], float F[4]) const noexcept;
+	void flexDistances(float const machinePos[3], float const distanceA,
+	                   float const distanceB, float const distanceC,
+	                   float const distanceD, float flex[HANGPRINTER_AXES]) const noexcept;
 
 #if DUAL_CAN
 	// Some CAN helpers


### PR DESCRIPTION
Previously, there were flex compensation in the inverse transform, but not in the forward transform.
This led to mesh bed compensation maps being a superposition of
 - actual bed irregularity, and
 - the flex compensation deployed by the inverse transform.

This new forward transform isn't perfectly mapping back and forth between the forward/inverse representations either.

But at least this version of the forward transform eliminates ~87% of the error that was introduced when the inverse transform got flex compensation.

The remaining ~13% of error is small enough that we can do mesh bed probing without turning off flex compensation first.

If a user wants to repeatedly jump back and forth between controlling motor position and controlling Cartesian position, like for example use G1 and G1 H2- moves interchangeably, then the 13% might become a problem. In such cases, the user would have to disable the flex compensation completely, to get better forward transform values.

For how I got the 87% number, see [the hangprinter-forward-transform repo](https://gitlab.com/tobben/hangprinter-forward-transform).

PS! The forward/inverse pair of transforms of Hangprinter actually didn't map perfectly back and forth, even before I introduced flex compensation. This is because the quadruple of motor positions almost never correspond perfectly to a well defined 3d position, so there will always be some qualified guesswork involved.