### PR TITLE
gitignore: ignore Emacs automatic backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # Misc
 /.settings/language.settings.xml
 
+# Emacs backup and auto-save files
+*~
+\#*\#
+
 # Output folders
 /Duet2/
 /Duet2_SBC/


### PR DESCRIPTION
I would totally understand if this doesn't get merged since only emacs users will enjoy this.
I loved eclipse. One of the greatest features was configurable warnings by project. Great options copotentially complaining about all shorts of things that made sense not to do in a project.

But then I got into the editor wars, and I tried vim first. Emacs with CUA mode was my real first start.
Anyway, back to the point...Eclipse is a great editor, or it was years ago. 
But there are potential contributors using other editors too.
Don't merge this yet. Let's turn this into an ongoing translation of your format file and an equivalent one for emacs.
I won't make all your format rules because some of them in eclipse are kind of hard to implement.
But I'm in urgent need of an emcas per-project file that doesn't allow me to put spaces where you meant tabs.
I hate to do that manually, not complaining about the per-project choice.
Both tabs and spaces are fine, it just has to be consistent within the project.
All editors have a way to do basic stuff for you, not just eclipse.

If you accept this, can I PR an emacs file for per project style file?
