### PR TITLE
Enable accelerometer support for Duet2 SBC

### DIFF
--- a/src/Config/Pins_DuetNG.h
+++ b/src/Config/Pins_DuetNG.h
@@ -71,11 +71,7 @@ constexpr uint32_t IAP_IMAGE_START = 0x20018000;	// IAP is loaded into the last 
 #define SUPPORT_DHT_SENSOR		1					// set nonzero to support DHT temperature/humidity sensors
 #define SUPPORT_WORKPLACE_COORDINATES	1			// set nonzero to support G10 L2 and G53..59
 #define SUPPORT_12864_LCD		1					// set nonzero to support 12864 LCD and rotary encoder
-#if defined(USE_SBC)
-# define SUPPORT_ACCELEROMETERS	0					// temporary until we can pass accelerometer data to the SBC
-#else
-# define SUPPORT_ACCELEROMETERS	1
-#endif
+#define SUPPORT_ACCELEROMETERS	1
 #define SUPPORT_OBJECT_MODEL	1
 #define SUPPORT_LED_STRIPS		1
 


### PR DESCRIPTION
Enable accelerometer support for duet2 SBC now that it works in SBC mode.