### PR TITLE
gitignore: ignore emacs' backup and auto-save files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # Misc
 /.settings/language.settings.xml
 
+# Emacs backup and auto-save files
+*~
+\#*\#
+
 # Output folders
 /Duet2/
 /Duet2_SBC/


### PR DESCRIPTION
Just for convenience for emacs users.
This is just like https://github.com/Duet3D/RepRapFirmware/pull/586 but reopened for 3.5-dev, as recommended by @dc42 .

See:

https://www.gnu.org/software/emacs/manual/html_node/elisp/Backup-Names.html
https://www.gnu.org/software/emacs/manual/html_node/elisp/Auto_002dSaving.html
