### PR TITLE
Generalize Hangprinter Anchors

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -609,7 +609,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/Networking/LwipEthernet/Lwip}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/Networking/LwipEthernet/Lwip/src/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/Networking/MQTT/MQTT_C/include}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/DuetWiFiSocketServer/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/DuetWifiSocketServer/src/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/FreeRTOS/src/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/FreeRTOS/src/portable/GCC/ARM_CM7/r0p1}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/RRFLibraries/src}&quot;"/>

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -532,69 +532,79 @@ AxesBitmap HangprinterKinematics::MustBeHomedAxes(AxesBitmap axesMoving, bool di
 // Write the parameters to a file, returning true if success
 bool HangprinterKinematics::WriteCalibrationParameters(FileStore *f) const noexcept
 {
-	bool ok = f->Write("; Hangprinter parameters\n");
-	if (ok)
+	bool ok = false;
+	String<255> scratchString;
+
+	scratchString.printf("; Hangprinter parameters\n");
+	scratchString.printf("M669 K6 ");
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	for (size_t i = 0; i < HANGPRINTER_AXES; ++i)
 	{
-		String<100> scratchString;
-		scratchString.printf("M669 K6 A%.3f:%.3f:%.3f B%.3f:%.3f:%.3f",
-							(double)anchors[A_AXIS][X_AXIS], (double)anchors[A_AXIS][Y_AXIS], (double)anchors[A_AXIS][Z_AXIS],
-							(double)anchors[B_AXIS][X_AXIS], (double)anchors[B_AXIS][Y_AXIS], (double)anchors[B_AXIS][Z_AXIS]);
-		ok = f->Write(scratchString.c_str());
-		if (ok)
-		{
-			scratchString.printf(" C%.3f:%.3f:%.3f D%.3f:%.3f:%.3f P%.1f\n",
-								(double)anchors[C_AXIS][X_AXIS], (double)anchors[C_AXIS][Y_AXIS], (double)anchors[C_AXIS][Z_AXIS],
-								(double)anchors[D_AXIS][X_AXIS], (double)anchors[D_AXIS][Y_AXIS], (double)anchors[D_AXIS][Z_AXIS],
-								(double)printRadius);
-			ok = f->Write(scratchString.c_str());
-			if (ok)
-			{
-				scratchString.printf("M666 Q%.6f R%.3f:%.3f:%.3f:%.3f U%d:%d:%d:%d",
-									(double)spoolBuildupFactor, (double)spoolRadii[A_AXIS],
-									(double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS],
-									(int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS],
-									(int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]
-						);
-				ok = f->Write(scratchString.c_str());
-				if (ok)
-				{
-					scratchString.printf(" O%d:%d:%d:%d L%d:%d:%d:%d H%d:%d:%d:%d J%d:%d:%d:%d",
-										(int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS],
-										(int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS],
-										(int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS],
-										(int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS],
-										(int)spoolGearTeeth[A_AXIS], (int)spoolGearTeeth[B_AXIS],
-										(int)spoolGearTeeth[C_AXIS], (int)spoolGearTeeth[D_AXIS],
-										(int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS],
-										(int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]
-							);
-					ok = f->Write(scratchString.c_str());
-					if (ok)
-					{
-						scratchString.printf(" W%.2f S%.2f I%.1f:%.1f:%.1f:%.1f X%.1f:%.1f:%.1f:%.1f",
-							(double)moverWeight_kg, (double)springKPerUnitLength,
-							(double)minPlannedForce_Newton[A_AXIS], (double)minPlannedForce_Newton[B_AXIS],
-							(double)minPlannedForce_Newton[C_AXIS], (double)minPlannedForce_Newton[D_AXIS],
-							(double)maxPlannedForce_Newton[A_AXIS], (double)maxPlannedForce_Newton[B_AXIS],
-							(double)maxPlannedForce_Newton[C_AXIS], (double)maxPlannedForce_Newton[D_AXIS]
-						);
-						ok = f->Write(scratchString.c_str());
-						if (ok)
-						{
-							scratchString.printf(" Y%.1f:%.1f:%.1f:%.1f T%.1f C%.4f:%.4f:%.4f:%.4f\n",
-								(double)guyWireLengths[A_AXIS], (double)guyWireLengths[B_AXIS],
-								(double)guyWireLengths[C_AXIS], (double)guyWireLengths[D_AXIS],
-								(double)targetForce_Newton,
-								(double)torqueConstants[A_AXIS], (double)torqueConstants[B_AXIS],
-								(double)torqueConstants[C_AXIS], (double)torqueConstants[D_AXIS]
-							);
-							ok = f->Write(scratchString.c_str());
-						}
-					}
-				}
-			}
-		}
+		scratchString.catf("%c%.3f:%.3f:%.3f ", ANCHOR_CHARS[i], (double)anchors[i][X_AXIS], (double)anchors[i][Y_AXIS], (double)anchors[i][Z_AXIS]);
 	}
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" P%.1f", (double)printRadius);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("M666 Q%.6f ", (double)spoolBuildupFactor);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("R%.3f:%.3f:%.3f:%.3f", (double)spoolRadii[A_AXIS], (double)spoolRadii[B_AXIS], (double)spoolRadii[C_AXIS], (double)spoolRadii[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf("U%d:%d:%d:%d", (int)mechanicalAdvantage[A_AXIS], (int)mechanicalAdvantage[B_AXIS], (int)mechanicalAdvantage[C_AXIS], (int)mechanicalAdvantage[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" O%d:%d:%d:%d", (int)linesPerSpool[A_AXIS], (int)linesPerSpool[B_AXIS], (int)linesPerSpool[C_AXIS], (int)linesPerSpool[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" L%d:%d:%d:%d", (int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS], (int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" H%d:%d:%d:%d", (int)motorGearTeeth[A_AXIS], (int)motorGearTeeth[B_AXIS], (int)motorGearTeeth[C_AXIS], (int)motorGearTeeth[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" J%d:%d:%d:%d", (int)fullStepsPerMotorRev[A_AXIS], (int)fullStepsPerMotorRev[B_AXIS], (int)fullStepsPerMotorRev[C_AXIS], (int)fullStepsPerMotorRev[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" W%.2f S%.2f", (double)moverWeight_kg, (double)springKPerUnitLength);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" I%.1f:%.1f:%.1f:%.1f",
+		(double)minPlannedForce_Newton[A_AXIS], (double)minPlannedForce_Newton[B_AXIS], (double)minPlannedForce_Newton[C_AXIS], (double)minPlannedForce_Newton[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" X%.1f:%.1f:%.1f:%.1f",
+		(double)maxPlannedForce_Newton[A_AXIS], (double)maxPlannedForce_Newton[B_AXIS], (double)maxPlannedForce_Newton[C_AXIS], (double)maxPlannedForce_Newton[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" Y%.1f:%.1f:%.1f:%.1f",
+		(double)guyWireLengths[A_AXIS], (double)guyWireLengths[B_AXIS], (double)guyWireLengths[C_AXIS], (double)guyWireLengths[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" T%.1f", (double)targetForce_Newton);
+	ok = f->Write(scratchString.c_str());
+	if (!ok) return false;
+
+	scratchString.printf(" C%.4f:%.4f:%.4f:%.4f\n", (double)torqueConstants[A_AXIS], (double)torqueConstants[B_AXIS], (double)torqueConstants[C_AXIS], (double)torqueConstants[D_AXIS]);
+	ok = f->Write(scratchString.c_str());
+
 	return ok;
 }
 

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -100,6 +100,7 @@ void HangprinterKinematics::Init() noexcept
 	constexpr float DefaultTorqueConstants[HANGPRINTER_AXES] = { 0.0F };
 
 	ARRAY_INIT(anchors, DefaultAnchors);
+	anchorMode = HangprinterAnchorMode::LastOnTop;
 	printRadius = DefaultPrintRadius;
 	spoolBuildupFactor = DefaultSpoolBuildupFactor;
 	ARRAY_INIT(spoolRadii, DefaultSpoolRadii);
@@ -234,6 +235,12 @@ bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const
 	}
 	else if (mCode == 666)
 	{
+		// 0=None, 1=last-top, 2=all-top, 3-half-top, etc
+		uint32_t unsignedAnchorMode = (uint32_t)anchorMode;
+		gb.TryGetUIValue('A', unsignedAnchorMode, seen);
+		if (unsignedAnchorMode <= (uint32_t)HangprinterAnchorMode::AllOnTop) {
+			anchorMode = (HangprinterAnchorMode)unsignedAnchorMode;
+		}
 		gb.TryGetFValue('Q', spoolBuildupFactor, seen);
 		gb.TryGetFloatArray('R', HANGPRINTER_AXES, spoolRadii, seen);
 		gb.TryGetUIArray('U', HANGPRINTER_AXES, mechanicalAdvantage, seen);
@@ -253,7 +260,7 @@ bool HangprinterKinematics::Configure(unsigned int mCode, GCodeBuffer& gb, const
 		}
 		else
 		{
-			reply.printf("M666 Q%.4f\n", (double)spoolBuildupFactor);
+			reply.printf("M666 A%u Q%.4f\n", (unsigned)anchorMode, (double)spoolBuildupFactor);
 
 			reply.lcatf("R%.2f", (double)spoolRadii[0]);
 			for (size_t i = 1; i < HANGPRINTER_AXES; ++i)
@@ -439,6 +446,29 @@ static bool isSameSide(float const v0[3], float const v1[3], float const v2[3], 
 	return dot0*dot1 > 0.0F;
 }
 
+bool HangprinterKinematics::IsInsidePyramidSides(float const coords[3]) const noexcept
+{
+	bool reachable = true;
+
+	// Check all the planes defined by triangle sides in the pyramid
+	for (size_t i = 0; reachable && i < HANGPRINTER_AXES - 1; ++i) {
+		reachable = reachable && isSameSide(anchors[i], anchors[(i+1) % (HANGPRINTER_AXES - 1)], anchors[HANGPRINTER_AXES - 1], anchors[(i+2) % (HANGPRINTER_AXES - 1)], coords);
+	}
+	return reachable;
+}
+
+bool HangprinterKinematics::IsInsidePrismSides(float const coords[3], unsigned const discount_last) const noexcept
+{
+	bool reachable = true;
+
+	// For each side of the base, check the plane formed by side and another point bellow them in z.
+	for (size_t i = 0; reachable && i < HANGPRINTER_AXES - discount_last; ++i) {
+		float const lower_point[3] = {anchors[i][0], anchors[i][1], anchors[i][2] - 1};
+		reachable = reachable && isSameSide(anchors[i], anchors[(i+1) % (HANGPRINTER_AXES - 1)], lower_point, anchors[(i+2) % (HANGPRINTER_AXES - 1)], coords);
+	}
+	return reachable;
+}
+
 // For each triangle side in a pseudo-pyramid, check if the point is inside the pyramid (Except for the base)
 // Also check that any point below the line between two exterior anchors (all anchors are exterior except for the last one)
 // is in the "inside part" all the way down to min_Z, however low it may be.
@@ -448,16 +478,19 @@ bool HangprinterKinematics::IsReachable(float axesCoords[MaxAxes], AxesBitmap ax
 	float const coords[3] = {axesCoords[X_AXIS], axesCoords[Y_AXIS], axesCoords[Z_AXIS]};
 	bool reachable = true;
 
-	// Check all the planes defined by triangle sides in the pyramid
-	for (size_t i = 0; reachable && i < HANGPRINTER_AXES - 1; ++i) {
-		reachable = reachable && isSameSide(anchors[i], anchors[(i+1) % (HANGPRINTER_AXES - 1)], anchors[HANGPRINTER_AXES - 1], anchors[(i+2) % (HANGPRINTER_AXES - 1)], coords);
-	}
+	switch (anchorMode) {
+		case HangprinterAnchorMode::None:
+			return true;
 
-	// For each side of the base, check the plane formed by side and another point bellow them in z.
-	for (size_t i = 0; reachable && i < HANGPRINTER_AXES - 1; ++i) {
-		float const lower_point[3] = {anchors[i][0], anchors[i][1], anchors[i][2] - 1};
-		reachable = reachable && isSameSide(anchors[i], anchors[(i+1) % (HANGPRINTER_AXES - 1)], lower_point, anchors[(i+2) % (HANGPRINTER_AXES - 1)], coords);
-	}
+		// This reaches a pyramid on top of the lower prism if the bed is below the lower anchors
+		case HangprinterAnchorMode::LastOnTop:
+		default:
+			reachable = IsInsidePyramidSides(coords);
+			return reachable && IsInsidePrismSides(coords, 1);
+
+		case HangprinterAnchorMode::AllOnTop:
+			return IsInsidePrismSides(coords, 0);
+	};
 
 	return reachable;
 }
@@ -581,7 +614,7 @@ bool HangprinterKinematics::WriteCalibrationParameters(FileStore *f) const noexc
 	ok = f->Write(scratchString.c_str());
 	if (!ok) return false;
 
-	scratchString.printf("M666 Q%.6f ", (double)spoolBuildupFactor);
+	scratchString.printf("M666 A%u Q%.6f ", (unsigned)anchorMode, (double)spoolBuildupFactor);
 	ok = f->Write(scratchString.c_str());
 	if (!ok) return false;
 

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -167,9 +167,6 @@ void HangprinterKinematics::Recalc() noexcept
 	}
 
 	//// Flex compensation
-	// If no guy wire lengths are configured, assume a default configuration
-	// with all spools stationary located at the last anchor,
-	// and that the last anchor is a top anchor
 	bool oneGuyWireNegative = false;
 	for (size_t i{0}; i < numAnchors; ++i) {
 		if (guyWireLengths[i] < 0.0F) {
@@ -177,11 +174,22 @@ void HangprinterKinematics::Recalc() noexcept
 			break;
 		}
 	}
-	if (oneGuyWireNegative) {
-		for (size_t i{0}; i < numAnchors - 1; ++i) {
-			guyWireLengths[i] = hyp3(anchors[i], anchors[numAnchors - 1]);
+
+	if (anchorMode == HangprinterAnchorMode::LastOnTop) {
+		// If no guy wire lengths are configured, assume a default configuration
+		// with all spools stationary located at the last anchor,
+		// and that the last anchor is a top anchor
+		if (oneGuyWireNegative) {
+			for (size_t i{0}; i < numAnchors - 1; ++i) {
+				guyWireLengths[i] = hyp3(anchors[i], anchors[numAnchors - 1]);
+			}
+			guyWireLengths[numAnchors - 1] = 0.0F;
 		}
-    guyWireLengths[numAnchors - 1] = 0.0F;
+	} else {
+		// Assumes no guyWires in all other cases
+		for (size_t i{0}; i < numAnchors; ++i) {
+			guyWireLengths[i] = 0.0F;
+		}
 	}
 
 	for (size_t i{0}; i < numAnchors; ++i) {
@@ -1149,8 +1157,8 @@ void HangprinterKinematics::StaticForces(float const machinePos[3], float F[HANG
 	static constexpr size_t B_AXIS = 1;
 	static constexpr size_t C_AXIS = 2;
 	static constexpr size_t D_AXIS = 3;
-  static constexpr size_t OLD_DEFAULT_NUM_ANCHORS = 4;
-  static constexpr size_t CARTESIAN_AXES = 3;
+	static constexpr size_t OLD_DEFAULT_NUM_ANCHORS = 4;
+	static constexpr size_t CARTESIAN_AXES = 3;
 
 	if (moverWeight_kg > 0.0001) { // mover weight more than one gram
 		float norm[OLD_DEFAULT_NUM_ANCHORS]; // Unit vector directions toward each anchor from mover

--- a/src/Movement/Kinematics/HangprinterKinematics.cpp
+++ b/src/Movement/Kinematics/HangprinterKinematics.cpp
@@ -439,17 +439,27 @@ static bool isSameSide(float const v0[3], float const v1[3], float const v2[3], 
 	return dot0*dot1 > 0.0F;
 }
 
-static bool isInsideTetrahedron(float const point[3], float const tetrahedron[4][3]){
-	return isSameSide(tetrahedron[0], tetrahedron[1], tetrahedron[2], tetrahedron[3], point) &&
-	       isSameSide(tetrahedron[2], tetrahedron[1], tetrahedron[3], tetrahedron[0], point) &&
-	       isSameSide(tetrahedron[2], tetrahedron[3], tetrahedron[0], tetrahedron[1], point) &&
-	       isSameSide(tetrahedron[0], tetrahedron[3], tetrahedron[1], tetrahedron[2], point);
-}
-
+// For each triangle side in a pseudo-pyramid, check if the point is inside the pyramid (Except for the base)
+// Also check that any point below the line between two exterior anchors (all anchors are exterior except for the last one)
+// is in the "inside part" all the way down to min_Z, however low it may be.
+// To further limit the movements in the X and Y axes one can simply set a smaller print radius.
 bool HangprinterKinematics::IsReachable(float axesCoords[MaxAxes], AxesBitmap axes) const noexcept /*override*/
 {
 	float const coords[3] = {axesCoords[X_AXIS], axesCoords[Y_AXIS], axesCoords[Z_AXIS]};
-	return isInsideTetrahedron(coords, anchors);
+	bool reachable = true;
+
+	// Check all the planes defined by triangle sides in the pyramid
+	for (size_t i = 0; reachable && i < HANGPRINTER_AXES - 1; ++i) {
+		reachable = reachable && isSameSide(anchors[i], anchors[(i+1) % (HANGPRINTER_AXES - 1)], anchors[HANGPRINTER_AXES - 1], anchors[(i+2) % (HANGPRINTER_AXES - 1)], coords);
+	}
+
+	// For each side of the base, check the plane formed by side and another point bellow them in z.
+	for (size_t i = 0; reachable && i < HANGPRINTER_AXES - 1; ++i) {
+		float const lower_point[3] = {anchors[i][0], anchors[i][1], anchors[i][2] - 1};
+		reachable = reachable && isSameSide(anchors[i], anchors[(i+1) % (HANGPRINTER_AXES - 1)], lower_point, anchors[(i+2) % (HANGPRINTER_AXES - 1)], coords);
+	}
+
+	return reachable;
 }
 
 // Limit the Cartesian position that the user wants to move to returning true if we adjusted the position

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -57,6 +57,7 @@ protected:
 
 private:
 	// Basic facts about movement system
+	const char* ANCHOR_CHARS = "ABCD";
 	static constexpr size_t HANGPRINTER_AXES = 4;
 	static constexpr size_t A_AXIS = 0;
 	static constexpr size_t B_AXIS = 1;

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -73,6 +73,8 @@ private:
 	void Init() noexcept;
 	void Recalc() noexcept;
 	void ForwardTransform(float const distances[HANGPRINTER_MAX_ANCHORS], float machinePos[3]) const noexcept;
+	void ForwardTransformTetrahedron(float const distances[HANGPRINTER_MAX_ANCHORS], float machinePos[3]) const noexcept;
+	void ForwardTransformQuadrilateralPyramid(float const distances[HANGPRINTER_MAX_ANCHORS], float machinePos[3]) const noexcept;
 	float MotorPosToLinePos(const int32_t motorPos, size_t axis) const noexcept;
 
 	void PrintParameters(const StringRef& reply) const noexcept;			// Print all the parameters for debugging

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -59,14 +59,10 @@ private:
 	// Basic facts about movement system
 	const char* ANCHOR_CHARS = "ABCD";
 	static constexpr size_t HANGPRINTER_AXES = 4;
-	static constexpr size_t A_AXIS = 0;
-	static constexpr size_t B_AXIS = 1;
-	static constexpr size_t C_AXIS = 2;
-	static constexpr size_t D_AXIS = 3;
 
 	void Init() noexcept;
 	void Recalc() noexcept;
-	void ForwardTransform(float a, float b, float c, float d, float machinePos[3]) const noexcept;
+	void ForwardTransform(float const distances[HANGPRINTER_AXES], float machinePos[3]) const noexcept;
 	float MotorPosToLinePos(const int32_t motorPos, size_t axis) const noexcept;
 
 	void PrintParameters(const StringRef& reply) const noexcept;			// Print all the parameters for debugging
@@ -111,9 +107,8 @@ private:
 
 	float SpringK(float const springLength) const noexcept;
 	void StaticForces(float const machinePos[3], float F[4]) const noexcept;
-	void flexDistances(float const machinePos[3], float const distanceA,
-	                   float const distanceB, float const distanceC,
-	                   float const distanceD, float flex[HANGPRINTER_AXES]) const noexcept;
+	void flexDistances(float const machinePos[3], float const distances[HANGPRINTER_AXES],
+	                   float flex[HANGPRINTER_AXES]) const noexcept;
 
 #if DUAL_CAN
 	// Some CAN helpers

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -15,7 +15,7 @@
 // Different modes can be configured for different tradeoffs in terms of printing volumes and speeds
 enum class HangprinterAnchorMode {
 	None, // All is reacheable in None anchor mode as printing volume
-	LastOnTop, // (Default) Rsults in a pyramid plus a prism below if the lower anchors are above the printing bed
+	LastOnTop, // (Default) Results in a pyramid plus a prism below if the lower anchors are above the printing bed
 	AllOnTop, // Result in a prism (speeds get limited, specially going down in Z)
 };
 
@@ -67,7 +67,7 @@ protected:
 
 private:
 	// Basic facts about movement system
-	const char* ANCHOR_CHARS = "ABCDIJKLO"; // anchors shouldn't be conflated with axes
+	const char* ANCHOR_CHARS = "ABCDIJKLO";
 	static constexpr size_t HANGPRINTER_MAX_ANCHORS = 5;
 
 	void Init() noexcept;

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -116,6 +116,8 @@ private:
 
 	float SpringK(float const springLength) const noexcept;
 	void StaticForces(float const machinePos[3], float F[HANGPRINTER_MAX_ANCHORS]) const noexcept;
+	void StaticForcesTetrahedron(float const machinePos[3], float F[HANGPRINTER_MAX_ANCHORS]) const noexcept;
+	void StaticForcesQuadrilateralPyramid(float const machinePos[3], float F[HANGPRINTER_MAX_ANCHORS]) const noexcept;
 	void flexDistances(float const machinePos[3], float const distances[HANGPRINTER_MAX_ANCHORS],
 	                   float flex[HANGPRINTER_MAX_ANCHORS]) const noexcept;
 

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -67,59 +67,57 @@ protected:
 
 private:
 	// Basic facts about movement system
-	const char* ANCHOR_CHARS = "ABCD";
-	static constexpr size_t HANGPRINTER_AXES = 4;
+	const char* ANCHOR_CHARS = "ABCDIJKLO"; // anchors shouldn't be conflated with axes
+	static constexpr size_t HANGPRINTER_MAX_ANCHORS = 5;
 
 	void Init() noexcept;
 	void Recalc() noexcept;
-	void ForwardTransform(float const distances[HANGPRINTER_AXES], float machinePos[3]) const noexcept;
+	void ForwardTransform(float const distances[HANGPRINTER_MAX_ANCHORS], float machinePos[3]) const noexcept;
 	float MotorPosToLinePos(const int32_t motorPos, size_t axis) const noexcept;
 
 	void PrintParameters(const StringRef& reply) const noexcept;			// Print all the parameters for debugging
 
 	// The real defaults are in the cpp file
 	HangprinterAnchorMode anchorMode = HangprinterAnchorMode::LastOnTop;
+	static size_t numAnchors;
 	float printRadius = 0.0F;
-	float anchors[HANGPRINTER_AXES][3] = {{ 0.0, 0.0, 0.0},
-	                                      { 0.0, 0.0, 0.0},
-	                                      { 0.0, 0.0, 0.0},
-	                                      { 0.0, 0.0, 0.0}};
+	float anchors[HANGPRINTER_MAX_ANCHORS][3];
 
 	// Line buildup compensation configurables
 
 	/* The real defaults are in the Init() function, since we sometimes need to reset
 	 * defaults during runtime */
 	float spoolBuildupFactor = 0.0F;
-	float spoolRadii[HANGPRINTER_AXES] = { 0.0F };
-	uint32_t mechanicalAdvantage[HANGPRINTER_AXES] = { 0 };
-	uint32_t linesPerSpool[HANGPRINTER_AXES] = { 0 };
-	uint32_t motorGearTeeth[HANGPRINTER_AXES] = { 0 };
-	uint32_t spoolGearTeeth[HANGPRINTER_AXES] = { 0 };
-	uint32_t fullStepsPerMotorRev[HANGPRINTER_AXES] = { 0 };
+	float spoolRadii[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	uint32_t mechanicalAdvantage[HANGPRINTER_MAX_ANCHORS] = { 0 };
+	uint32_t linesPerSpool[HANGPRINTER_MAX_ANCHORS] = { 0 };
+	uint32_t motorGearTeeth[HANGPRINTER_MAX_ANCHORS] = { 0 };
+	uint32_t spoolGearTeeth[HANGPRINTER_MAX_ANCHORS] = { 0 };
+	uint32_t fullStepsPerMotorRev[HANGPRINTER_MAX_ANCHORS] = { 0 };
 
 	// Flex compensation configurables
 	float moverWeight_kg = 0.0F;
 	float springKPerUnitLength = 0.0F;
-	float minPlannedForce_Newton[HANGPRINTER_AXES] = { 0.0F };
-	float maxPlannedForce_Newton[HANGPRINTER_AXES] = { 0.0F };
-	float guyWireLengths[HANGPRINTER_AXES] = { 0.0F };
+	float minPlannedForce_Newton[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	float maxPlannedForce_Newton[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	float guyWireLengths[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
 	float targetForce_Newton = 0.0F;
-	float torqueConstants[HANGPRINTER_AXES] = { 0.0F };
+	float torqueConstants[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
 
 	// Derived parameters
-	float k0[HANGPRINTER_AXES] = { 0.0F };
-	float spoolRadiiSq[HANGPRINTER_AXES] = { 0.0F };
-	float k2[HANGPRINTER_AXES] = { 0.0F };
-	float distancesOrigin[HANGPRINTER_AXES] = { 0.0F };
-	float springKsOrigin[HANGPRINTER_AXES] = { 0.0F };
-	float relaxedSpringLengthsOrigin[HANGPRINTER_AXES] = { 0.0F };
-	float fOrigin[HANGPRINTER_AXES] = { 0.0F };
+	float k0[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	float spoolRadiiSq[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	float k2[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	float distancesOrigin[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	float springKsOrigin[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	float relaxedSpringLengthsOrigin[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
+	float fOrigin[HANGPRINTER_MAX_ANCHORS] = { 0.0F };
 	float printRadiusSquared = 0.0F;
 
 	float SpringK(float const springLength) const noexcept;
-	void StaticForces(float const machinePos[3], float F[4]) const noexcept;
-	void flexDistances(float const machinePos[3], float const distances[HANGPRINTER_AXES],
-	                   float flex[HANGPRINTER_AXES]) const noexcept;
+	void StaticForces(float const machinePos[3], float F[HANGPRINTER_MAX_ANCHORS]) const noexcept;
+	void flexDistances(float const machinePos[3], float const distances[HANGPRINTER_MAX_ANCHORS],
+	                   float flex[HANGPRINTER_MAX_ANCHORS]) const noexcept;
 
 #if DUAL_CAN
 	// Some CAN helpers

--- a/src/Movement/Kinematics/HangprinterKinematics.h
+++ b/src/Movement/Kinematics/HangprinterKinematics.h
@@ -12,6 +12,13 @@
 
 #if SUPPORT_HANGPRINTER
 
+// Different modes can be configured for different tradeoffs in terms of printing volumes and speeds
+enum class HangprinterAnchorMode {
+	None, // All is reacheable in None anchor mode as printing volume
+	LastOnTop, // (Default) Rsults in a pyramid plus a prism below if the lower anchors are above the printing bed
+	AllOnTop, // Result in a prism (speeds get limited, specially going down in Z)
+};
+
 class HangprinterKinematics : public RoundBedKinematics
 {
 public:
@@ -55,6 +62,9 @@ public:
 protected:
 	DECLARE_OBJECT_MODEL_WITH_ARRAYS
 
+	bool IsInsidePyramidSides(float const coords[3]) const noexcept;
+	bool IsInsidePrismSides(float const coords[3], unsigned const discount_last) const noexcept;
+
 private:
 	// Basic facts about movement system
 	const char* ANCHOR_CHARS = "ABCD";
@@ -68,6 +78,7 @@ private:
 	void PrintParameters(const StringRef& reply) const noexcept;			// Print all the parameters for debugging
 
 	// The real defaults are in the cpp file
+	HangprinterAnchorMode anchorMode = HangprinterAnchorMode::LastOnTop;
 	float printRadius = 0.0F;
 	float anchors[HANGPRINTER_AXES][3] = {{ 0.0, 0.0, 0.0},
 	                                      { 0.0, 0.0, 0.0},


### PR DESCRIPTION
This one builds on top of #603, #601, #598, two own commits, #597, in that order. So it includes everything me and @jtimon have been working on, but also:

 - Line Flex Compensation for Hangprinters with 5 anchors in a 4 low, 1 high configuration. :tada:

The algorithm has been developed in this repo: [https://gitlab.com/tobben/hangprinter-flex-compensation](hangprinter-flex-compensation), and copy-pasted into RRF and back again, so both are identical, and one of them has been plotted and visually inspected.

This PR will need some testing on hw before an eventual merge.

Me and @jtimon might work in different directions soon, so this is a good place for jtimon to find my most recent commits related to anchor generalization, as well as my testing status on hw.