### PR TITLE
WIP: add line and column number to error reporting.

### DIFF
--- a/src/CAN/CanInterface.cpp
+++ b/src/CAN/CanInterface.cpp
@@ -448,7 +448,7 @@ void CanInterface::CheckCanAddress(uint32_t address, const GCodeBuffer& gb) THRO
 {
 	if (address == 0 || address > CanId::MaxCanAddress)
 	{
-		throw GCodeException(gb.GetLineNumber(), -1, "CAN address out of range");
+		throw GCodeException(&gb, -1, "CAN address out of range");
 	}
 }
 

--- a/src/GCodes/GCodeBuffer/BinaryParser.cpp
+++ b/src/GCodes/GCodeBuffer/BinaryParser.cpp
@@ -927,17 +927,17 @@ void BinaryParser::AddParameters(VariableSet& vs, int codeRunning) THROWS(GCodeE
 
 GCodeException BinaryParser::ConstructParseException(const char *str) const noexcept
 {
-	return GCodeException(header->lineNumber, -1, str);
+	return GCodeException(&gb, -1, str);
 }
 
 GCodeException BinaryParser::ConstructParseException(const char *str, const char *param) const noexcept
 {
-	return GCodeException(header->lineNumber, -1, str, param);
+	return GCodeException(&gb, -1, str, param);
 }
 
 GCodeException BinaryParser::ConstructParseException(const char *str, uint32_t param) const noexcept
 {
-	return GCodeException(header->lineNumber, -1, str, param);
+	return GCodeException(&gb, -1, str, param);
 }
 
 #endif

--- a/src/GCodes/GCodeBuffer/ExpressionParser.cpp
+++ b/src/GCodes/GCodeBuffer/ExpressionParser.cpp
@@ -122,7 +122,7 @@ void ExpressionParser::ParseExpectKet(ExpressionValue& rslt, bool evaluate, char
 				}
 				else if (evaluate)
 				{
-					throw GCodeException(gb.GetLineNumber(), indexCol, "array index out of range");
+					throw GCodeException(&gb, indexCol, "array index out of range");
 				}
 				else
 				{
@@ -138,7 +138,7 @@ void ExpressionParser::ParseExpectKet(ExpressionValue& rslt, bool evaluate, char
 				{
 					if (evaluate)
 					{
-						throw GCodeException(gb.GetLineNumber(), indexCol, "array index out of range");
+						throw GCodeException(&gb, indexCol, "array index out of range");
 					}
 					else
 					{
@@ -151,7 +151,7 @@ void ExpressionParser::ParseExpectKet(ExpressionValue& rslt, bool evaluate, char
 		default:
 			if (evaluate)
 			{
-				throw GCodeException(gb.GetLineNumber(), indexCol, "left operand of [ ] is not an array");
+				throw GCodeException(&gb, indexCol, "left operand of [ ] is not an array");
 			}
 			rslt.SetNull(nullptr);
 			break;
@@ -2056,17 +2056,17 @@ int ExpressionParser::GetColumn() const noexcept
 
 void ExpressionParser::ThrowParseException(const char *str) const THROWS(GCodeException)
 {
-	throw GCodeException(gb.GetLineNumber(), GetColumn(), str);
+	throw GCodeException(&gb, GetColumn(), str);
 }
 
 void ExpressionParser::ThrowParseException(const char *str, const char *param) const THROWS(GCodeException)
 {
-	throw GCodeException(gb.GetLineNumber(), GetColumn(), str, param);
+	throw GCodeException(&gb, GetColumn(), str, param);
 }
 
 void ExpressionParser::ThrowParseException(const char *str, uint32_t param) const THROWS(GCodeException)
 {
-	throw GCodeException(gb.GetLineNumber(), GetColumn(), str, param);
+	throw GCodeException(&gb, GetColumn(), str, param);
 }
 
 // Call this before making a recursive call, or before calling a function that needs a lot of stack from a recursive function
@@ -2084,7 +2084,7 @@ void ExpressionParser::CheckStack(uint32_t calledFunctionStackUsage) const THROW
 	// The stack is in danger of overflowing. Throw an exception if we have enough stack to do so (ideally, this should always be the case)
 	if (stackLimit + StackUsage::Throw <= stackPtr)
 	{
-		throw GCodeException(gb.GetLineNumber(), GetColumn(), "Expression nesting too deep");
+		throw GCodeException(&gb, GetColumn(), "Expression nesting too deep");
 	}
 
 	// Not enough stack left to throw an exception

--- a/src/GCodes/GCodeBuffer/GCodeBuffer.cpp
+++ b/src/GCodes/GCodeBuffer/GCodeBuffer.cpp
@@ -432,7 +432,7 @@ void GCodeBuffer::MustSee(char c) THROWS(GCodeException)
 {
 	if (!Seen(c))
 	{
-		throw GCodeException(GetLineNumber(), -1, "missing parameter '%c'", (uint32_t)c);
+		throw GCodeException(this, -1, "missing parameter '%c'", (uint32_t)c);
 	}
 }
 
@@ -441,7 +441,7 @@ char GCodeBuffer::MustSee(char c1, char c2) THROWS(GCodeException)
 {
 	if (Seen(c1)) { return c1; }
 	if (Seen(c2)) { return c2; }
-	throw GCodeException(GetLineNumber(), -1, "missing parameter '%c'", (uint32_t)c1);
+	throw GCodeException(this, -1, "missing parameter '%c'", (uint32_t)c1);
 }
 
 // Get a float after a key letter
@@ -460,7 +460,7 @@ float GCodeBuffer::GetPositiveFValue() THROWS(GCodeException)
 							stringParser.GetColumn();
 	const float val = GetFValue();
 	if (val > 0.0) { return val; }
-	throw GCodeException(GetLineNumber(), column, "value must be greater than zero");
+	throw GCodeException(this, column, "value must be greater than zero");
 }
 
 // Get a float after a key letter and check that it is greater than or equal to zero
@@ -473,7 +473,7 @@ float GCodeBuffer::GetNonNegativeFValue() THROWS(GCodeException)
 							stringParser.GetColumn();
 	const float val = GetFValue();
 	if (val >= 0.0) { return val; }
-	throw GCodeException(GetLineNumber(), column, "value must be not less than zero");
+	throw GCodeException(this, column, "value must be not less than zero");
 }
 
 float GCodeBuffer::GetLimitedFValue(char c, float minValue, float maxValue) THROWS(GCodeException)
@@ -485,8 +485,8 @@ float GCodeBuffer::GetLimitedFValue(char c, float minValue, float maxValue) THRO
 #endif
 							stringParser.GetColumn();
 	const float ret = GetFValue();
-	if (ret < minValue) { throw GCodeException(GetLineNumber(), column, "parameter '%c' too low", (uint32_t)c); }
-	if (ret > maxValue) { throw GCodeException(GetLineNumber(), column, "parameter '%c' too high", (uint32_t)c); }
+	if (ret < minValue) { throw GCodeException(this, column, "parameter '%c' too low", (uint32_t)c); }
+	if (ret > maxValue) { throw GCodeException(this, column, "parameter '%c' too high", (uint32_t)c); }
 	return ret;
 }
 
@@ -527,11 +527,11 @@ int32_t GCodeBuffer::GetLimitedIValue(char c, int32_t minValue, int32_t maxValue
 	const int32_t ret = GetIValue();
 	if (ret < minValue)
 	{
-		throw GCodeException(GetLineNumber(), -1, "parameter '%c' too low", (uint32_t)c);
+		throw GCodeException(this, -1, "parameter '%c' too low", (uint32_t)c);
 	}
 	if (ret > maxValue)
 	{
-		throw GCodeException(GetLineNumber(), -1, "parameter '%c' too high", (uint32_t)c);
+		throw GCodeException(this, -1, "parameter '%c' too high", (uint32_t)c);
 	}
 	return ret;
 }
@@ -549,11 +549,11 @@ uint32_t GCodeBuffer::GetLimitedUIValue(char c, uint32_t minValue, uint32_t maxV
 	const uint32_t ret = GetUIValue();
 	if (ret < minValue)
 	{
-		throw GCodeException(GetLineNumber(), -1, "parameter '%c' too low", (uint32_t)c);
+		throw GCodeException(this, -1, "parameter '%c' too low", (uint32_t)c);
 	}
 	if (ret >= maxValuePlusOne)
 	{
-		throw GCodeException(GetLineNumber(), -1, "parameter '%c' too high", (uint32_t)c);
+		throw GCodeException(this, -1, "parameter '%c' too high", (uint32_t)c);
 	}
 	return ret;
 }
@@ -1321,7 +1321,7 @@ void GCodeBuffer::ThrowGCodeException(const char *msg) const THROWS(GCodeExcepti
 						(isBinaryBuffer) ? -1 :
 #endif
 							stringParser.GetColumn();
-	throw GCodeException(GetLineNumber(), column, msg);
+	throw GCodeException(this, column, msg);
 }
 
 void GCodeBuffer::ThrowGCodeException(const char *msg, uint32_t param) const THROWS(GCodeException)
@@ -1331,7 +1331,7 @@ void GCodeBuffer::ThrowGCodeException(const char *msg, uint32_t param) const THR
 						(isBinaryBuffer) ? -1 :
 #endif
 							stringParser.GetColumn();
-	throw GCodeException(GetLineNumber(), column, msg, param);
+	throw GCodeException(this, column, msg, param);
 }
 
 #if SUPPORT_COORDINATE_ROTATION

--- a/src/GCodes/GCodeBuffer/StringParser.cpp
+++ b/src/GCodes/GCodeBuffer/StringParser.cpp
@@ -352,7 +352,7 @@ bool StringParser::CheckMetaCommand(const StringRef& reply) THROWS(GCodeExceptio
 {
 	if (overflowed)
 	{
-		throw GCodeException(gb.GetLineNumber(), ARRAY_SIZE(gb.buffer) + commandIndent - 1, "GCode command too long");
+		throw GCodeException(&gb, ARRAY_SIZE(gb.buffer) + commandIndent - 1, "GCode command too long");
 	}
 
 	const bool doingFile = gb.IsDoingFile();
@@ -878,11 +878,11 @@ void StringParser::ProcessEchoCommand(const StringRef& reply) THROWS(GCodeExcept
 		FileStore * const f = reprap.GetPlatform().OpenSysFile(filename.c_str(), openMode);
 		if (f == nullptr)
 		{
-			throw GCodeException(gb.GetLineNumber(), readPointer + commandIndent, "Failed to create or open file");
+			throw GCodeException(&gb, readPointer + commandIndent, "Failed to create or open file");
 		}
 		outputFile.Set(f);
 #else
-		throw GCodeException(gb.GetLineNumber(), readPointer + commandIndent, "Can't write to this file system");
+		throw GCodeException(&gb, readPointer + commandIndent, "Can't write to this file system");
 #endif
 	}
 
@@ -924,7 +924,7 @@ void StringParser::ProcessEchoCommand(const StringRef& reply) THROWS(GCodeExcept
 		reply.Clear();
 		if (!ok)
 		{
-			throw GCodeException(gb.GetLineNumber(), -1, "Failed to write to redirect file");
+			throw GCodeException(&gb, -1, "Failed to write to redirect file");
 		}
 	}
 #endif
@@ -2052,17 +2052,17 @@ void StringParser::AddParameters(VariableSet& vs, int codeRunning) THROWS(GCodeE
 
 GCodeException StringParser::ConstructParseException(const char *str) const noexcept
 {
-	return GCodeException(gb.GetLineNumber(), GetColumn(), str);
+	return GCodeException(&gb, GetColumn(), str);
 }
 
 GCodeException StringParser::ConstructParseException(const char *str, const char *param) const noexcept
 {
-	return GCodeException(gb.GetLineNumber(), GetColumn(), str, param);
+	return GCodeException(&gb, GetColumn(), str, param);
 }
 
 GCodeException StringParser::ConstructParseException(const char *str, uint32_t param) const noexcept
 {
-	return GCodeException(gb.GetLineNumber(), GetColumn(), str, param);
+	return GCodeException(&gb, GetColumn(), str, param);
 }
 
 // Get the current column if we can, else return -1

--- a/src/GCodes/GCodeException.cpp
+++ b/src/GCodes/GCodeException.cpp
@@ -17,21 +17,21 @@ GCodeException::GCodeException(const GCodeBuffer *null gb, int col, const char *
 		line = gb->GetLineNumber();
 		if (gb->IsDoingFileMacro())
 		{
-			source = GCodeExceptionSource::MACRO;
+			source = GCodeExceptionSource::macro;
 		}
 		else if (gb->IsDoingFile())
 		{
-			source = GCodeExceptionSource::FILE;
+			source = GCodeExceptionSource::file;
 		}
 		else
 		{
-			source = GCodeExceptionSource::OTHER;
+			source = GCodeExceptionSource::other;
 			line = -1;
 		}
 	}
 	else
 	{
-		source = GCodeExceptionSource::OTHER;
+		source = GCodeExceptionSource::other;
 		line = -1;
 	}
 }
@@ -50,21 +50,19 @@ GCodeException::GCodeException(const GCodeBuffer *null gb, int col, const char *
 void GCodeException::GetMessage(const StringRef &reply, const GCodeBuffer *null gb) const noexcept
 {
 	// Print the file location, if possible
-	if (gb != nullptr)
+	switch(source)
 	{
-		switch(source)
-		{
-		case GCodeExceptionSource::FILE:
-			reply.copy("in GCode file");
-			break;
-		case GCodeExceptionSource::MACRO:
-			reply.copy("in file macro");
-			break;
-		case GCodeExceptionSource::OTHER:
-		default:
-			break;
-		}
+	case GCodeExceptionSource::file:
+		reply.copy("in GCode file");
+		break;
+	case GCodeExceptionSource::macro:
+		reply.copy("in file macro");
+		break;
+	case GCodeExceptionSource::other:
+	default:
+		break;
 	}
+
 	if (line >= 0)
 	{
 		reply.catf(" line %d", line);

--- a/src/GCodes/GCodeException.cpp
+++ b/src/GCodes/GCodeException.cpp
@@ -10,27 +10,73 @@
 #include <General/StringRef.h>
 #include <GCodes/GCodeBuffer/GCodeBuffer.h>
 
+GCodeException::GCodeException(const GCodeBuffer *null gb, int col, const char *_ecv_array msg) noexcept : column(col), message(msg)
+{
+	if (gb != nullptr)
+	{
+		line = gb->GetLineNumber();
+		if (gb->IsDoingFileMacro())
+		{
+			source = GCodeExceptionSource::MACRO;
+		}
+		else if (gb->IsDoingFile())
+		{
+			source = GCodeExceptionSource::FILE;
+		}
+		else
+		{
+			source = GCodeExceptionSource::OTHER;
+			line = -1;
+		}
+	}
+	else
+	{
+		source = GCodeExceptionSource::OTHER;
+		line = -1;
+	}
+}
+
+GCodeException::GCodeException(const GCodeBuffer *null gb, int col, const char *_ecv_array msg, uint32_t uparam) noexcept : GCodeException(gb, col, msg)
+{
+	param.u = uparam;
+}
+
+GCodeException::GCodeException(const GCodeBuffer *null gb, int col, const char *_ecv_array msg, const char *_ecv_array sparam) noexcept : GCodeException(gb, col, msg)
+{
+	stringParam.copy(sparam);
+}
+
 // Construct the error message. This will be prefixed with "Error: " when it is returned to the user.
 void GCodeException::GetMessage(const StringRef &reply, const GCodeBuffer *null gb) const noexcept
 {
 	// Print the file location, if possible
-	const bool inFile = gb != nullptr && gb->IsDoingFile();
-	if (inFile)
+	if (gb != nullptr)
 	{
-		reply.copy((gb->IsDoingFileMacro()) ? "in file macro" : "in GCode file");
-		if (line >= 0)
+		switch(source)
 		{
-			reply.catf(" line %d", line);
-			if (column >= 0)
-			{
-				reply.catf(" column %d", column + 1);
-			}
+		case GCodeExceptionSource::FILE:
+			reply.copy("in GCode file");
+			break;
+		case GCodeExceptionSource::MACRO:
+			reply.copy("in file macro");
+			break;
+		case GCodeExceptionSource::OTHER:
+		default:
+			break;
+		}
+	}
+	if (line >= 0)
+	{
+		reply.catf(" line %d", line);
+		if (column >= 0)
+		{
+			reply.catf(" column %d", column + 1);
 		}
 		reply.cat(": ");
 	}
 	else if (column >= 0)
 	{
-		reply.printf("at column %d: ", column + 1);
+		reply.catf(" at column %d: ", column + 1);
 	}
 	else
 	{

--- a/src/GCodes/GCodeException.h
+++ b/src/GCodes/GCodeException.h
@@ -18,9 +18,9 @@ namespace StackUsage
 
 enum class GCodeExceptionSource : uint8_t
 {
-	OTHER,
-	FILE,
-	MACRO,
+	other,
+	file,
+	macro,
 };
 
 // This class is mostly used to throw exceptions when processing GCode. It is also used to store error messages that need to be retrieved later.
@@ -29,22 +29,22 @@ enum class GCodeExceptionSource : uint8_t
 class GCodeException
 {
 public:
-	GCodeException() noexcept : line(-1), column(-1), message(nullptr), source(GCodeExceptionSource::OTHER) { }
-	explicit GCodeException(const char *_ecv_array msg) noexcept: line(-1), column(-1), message(msg), source(GCodeExceptionSource::OTHER) { }
+	GCodeException() noexcept : line(-1), column(-1), message(nullptr), source(GCodeExceptionSource::other) { }
+	explicit GCodeException(const char *_ecv_array msg) noexcept: line(-1), column(-1), message(msg), source(GCodeExceptionSource::other) { }
 
-	GCodeException(int lin, int col, const char *_ecv_array msg) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::OTHER)  { }
+	GCodeException(int lin, int col, const char *_ecv_array msg) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::other)  { }
 
-	GCodeException(int lin, int col, const char *_ecv_array msg, const char *_ecv_array sparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::OTHER)
+	GCodeException(int lin, int col, const char *_ecv_array msg, const char *_ecv_array sparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::other)
 	{
 		stringParam.copy(sparam);
 	}
 
-	GCodeException(int lin, int col, const char *_ecv_array msg, uint32_t uparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::OTHER)
+	GCodeException(int lin, int col, const char *_ecv_array msg, uint32_t uparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::other)
 	{
 		param.u = uparam;
 	}
 
-	GCodeException(int lin, int col, const char *_ecv_array msg, int32_t iparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::OTHER)
+	GCodeException(int lin, int col, const char *_ecv_array msg, int32_t iparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::other)
 	{
 		param.i = iparam;
 	}

--- a/src/GCodes/GCodeException.h
+++ b/src/GCodes/GCodeException.h
@@ -16,31 +16,44 @@ namespace StackUsage
 	constexpr uint32_t Margin = 300;					// the margin we allow for calls to non-recursive functions that can throw
 }
 
+enum class GCodeExceptionSource : uint8_t
+{
+	OTHER,
+	FILE,
+	MACRO,
+};
+
 // This class is mostly used to throw exceptions when processing GCode. It is also used to store error messages that need to be retrieved later.
 // Field "message" should always point to a constant string in flash memory, or be null.
 // The error message may have a string, int32_t or uint32_t parameter
 class GCodeException
 {
 public:
-	GCodeException() noexcept : line(-1), column(-1), message(nullptr) { }
-	explicit GCodeException(const char *_ecv_array msg) noexcept: line(-1), column(-1), message(msg) { }
+	GCodeException() noexcept : line(-1), column(-1), message(nullptr), source(GCodeExceptionSource::OTHER) { }
+	explicit GCodeException(const char *_ecv_array msg) noexcept: line(-1), column(-1), message(msg), source(GCodeExceptionSource::OTHER) { }
 
-	GCodeException(int lin, int col, const char *_ecv_array msg) noexcept : line(lin), column(col), message(msg)  { }
+	GCodeException(int lin, int col, const char *_ecv_array msg) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::OTHER)  { }
 
-	GCodeException(int lin, int col, const char *_ecv_array msg, const char *_ecv_array sparam) noexcept : line(lin), column(col), message(msg)
+	GCodeException(int lin, int col, const char *_ecv_array msg, const char *_ecv_array sparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::OTHER)
 	{
 		stringParam.copy(sparam);
 	}
 
-	GCodeException(int lin, int col, const char *_ecv_array msg, uint32_t uparam) noexcept : line(lin), column(col), message(msg)
+	GCodeException(int lin, int col, const char *_ecv_array msg, uint32_t uparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::OTHER)
 	{
 		param.u = uparam;
 	}
 
-	GCodeException(int lin, int col, const char *_ecv_array msg, int32_t iparam) noexcept : line(lin), column(col), message(msg)
+	GCodeException(int lin, int col, const char *_ecv_array msg, int32_t iparam) noexcept : line(lin), column(col), message(msg), source(GCodeExceptionSource::OTHER)
 	{
 		param.i = iparam;
 	}
+
+	GCodeException(const GCodeBuffer *null gb, int col, const char *_ecv_array msg) noexcept;
+
+	GCodeException(const GCodeBuffer *null gb, int col, const char *_ecv_array msg, uint32_t uparam) noexcept;
+
+	GCodeException(const GCodeBuffer *null gb, int col, const char *_ecv_array msg, const char *_ecv_array sparam) noexcept;
 
 	void GetMessage(const StringRef& reply, const GCodeBuffer *null gb) const noexcept;
 
@@ -50,6 +63,7 @@ private:
 	int line;
 	int column;
 	const char *_ecv_array _ecv_null message;
+	GCodeExceptionSource source;
 	union
 	{
 		int32_t i;

--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -1961,7 +1961,7 @@ bool GCodes::DoStraightMove(GCodeBuffer& gb, bool isCoordinated) THROWS(GCodeExc
 		}
 		else
 		{
-			gb.ThrowGCodeException("G0/G1: bad restore point number");
+			gb.ThrowGCodeException("bad restore point number");
 		}
 	}
 
@@ -2032,7 +2032,7 @@ bool GCodes::DoStraightMove(GCodeBuffer& gb, bool isCoordinated) THROWS(GCodeExc
 			// If it is a special move on a delta, movement must be relative.
 			if (ms.moveType != 0 && !gb.LatestMachineState().axesRelative && reprap.GetMove().GetKinematics().GetKinematicsType() == KinematicsType::linearDelta)
 			{
-				gb.ThrowGCodeException("G0/G1: attempt to move individual motors of a delta machine to absolute positions");
+				gb.ThrowGCodeException("attempt to move individual motors of a delta machine to absolute positions");
 			}
 
 			axesMentioned.SetBit(axis);
@@ -2109,7 +2109,7 @@ bool GCodes::DoStraightMove(GCodeBuffer& gb, bool isCoordinated) THROWS(GCodeExc
 
 		if (!doingManualBedProbe && CheckEnoughAxesHomed(axesMentioned))
 		{
-			gb.ThrowGCodeException("G0/G1: insufficient axes homed");
+			gb.ThrowGCodeException("insufficient axes homed");
 		}
 	}
 	else
@@ -2227,7 +2227,7 @@ bool GCodes::DoStraightMove(GCodeBuffer& gb, bool isCoordinated) THROWS(GCodeExc
 		case LimitPositionResult::adjustedAndIntermediateUnreachable:
 			if (machineType != MachineType::fff)
 			{
-				gb.ThrowGCodeException("G0/G1: target position outside machine limits");	// it's a laser or CNC so this is a definite error
+				gb.ThrowGCodeException("target position outside machine limits");	// it's a laser or CNC so this is a definite error
 			}
 			ToolOffsetInverseTransform(ms);									// make sure the limits are reflected in the user position
 			if (lp == LimitPositionResult::adjusted)
@@ -2253,7 +2253,7 @@ bool GCodes::DoStraightMove(GCodeBuffer& gb, bool isCoordinated) THROWS(GCodeExc
 					break;
 				}
 			}
-			gb.ThrowGCodeException("G0/G1: target position not reachable from current position");		// we can't bring the move within limits, so this is a definite error
+			gb.ThrowGCodeException("target position not reachable from current position");		// we can't bring the move within limits, so this is a definite error
 			// no break
 
 		case LimitPositionResult::ok:
@@ -2427,7 +2427,7 @@ bool GCodes::DoArcMove(GCodeBuffer& gb, bool clockwise)
 		// The distance between start and end points must not be zero
 		if (dSquared == 0.0)
 		{
-			gb.ThrowGCodeException("G2/G3: distance between start and end points must not be zero when specifying a radius");
+			gb.ThrowGCodeException("distance between start and end points must not be zero when specifying a radius");
 		}
 
 		// The perpendicular must have a real length (possibly zero)
@@ -2443,7 +2443,7 @@ bool GCodes::DoArcMove(GCodeBuffer& gb, bool clockwise)
 		{
 			if (hSquared < -0.02 * fsquare(rParam))							// allow the radius to be up to 1% too short
 			{
-				gb.ThrowGCodeException("G2/G3: radius is too small to reach endpoint");
+				gb.ThrowGCodeException("radius is too small to reach endpoint");
 			}
 			hDivD = 0.0;													// this has the effect of increasing the radius slightly so that the maths works
 		}
@@ -2480,7 +2480,7 @@ bool GCodes::DoArcMove(GCodeBuffer& gb, bool clockwise)
 
 		if (iParam == 0.0 && jParam == 0.0)			// at least one of IJK must be specified and nonzero
 		{
-			gb.ThrowGCodeException("G2/G3: no I J K or R parameter");
+			gb.ThrowGCodeException("no I J K or R parameter");
 		}
 	}
 
@@ -2547,7 +2547,7 @@ bool GCodes::DoArcMove(GCodeBuffer& gb, bool clockwise)
 
 	if (CheckEnoughAxesHomed(realAxesMoving))
 	{
-		gb.ThrowGCodeException("G2/G3: insufficient axes homed");
+		gb.ThrowGCodeException("insufficient axes homed");
 	}
 
 	// Compute the initial and final angles. Do this before we possibly rotate the coordinates of the arc centre.
@@ -2587,7 +2587,7 @@ bool GCodes::DoArcMove(GCodeBuffer& gb, bool clockwise)
 
 	if (reprap.GetMove().GetKinematics().LimitPosition(ms.coords, nullptr, numVisibleAxes, axesVirtuallyHomed, true, limitAxes) != LimitPositionResult::ok)
 	{
-		gb.ThrowGCodeException("G2/G3: outside machine limits");				// abandon the move
+		gb.ThrowGCodeException("outside machine limits");				// abandon the move
 	}
 
 	// Set up default move parameters

--- a/src/GCodes/GCodes4.cpp
+++ b/src/GCodes/GCodes4.cpp
@@ -92,7 +92,7 @@ void GCodes::RunStateMachine(GCodeBuffer& gb, const StringRef& reply) noexcept
 			{
 				break;
 			}
-			gb.LatestMachineState().SetError("G1/G2/G3: intermediate position outside machine limits");
+			gb.LatestMachineState().SetError("intermediate position outside machine limits");
 			gb.SetState(GCodeState::normal);
 			if (machineType != MachineType::fff)
 			{

--- a/src/GCodes/GCodes6.cpp
+++ b/src/GCodes/GCodes6.cpp
@@ -641,11 +641,11 @@ size_t GCodes::FindAxisLetter(GCodeBuffer& gb) THROWS(GCodeException)
 			{
 				return axis;
 			}
-			throw GCodeException(gb.GetLineNumber(), -1, "%c axis has not been homed", (uint32_t)axisLetters[axis]);
+			throw GCodeException(&gb, -1, "%c axis has not been homed", (uint32_t)axisLetters[axis]);
 		}
 	}
 
-	throw GCodeException(gb.GetLineNumber(), -1, "No axis specified");
+	throw GCodeException(&gb, -1, "No axis specified");
 }
 
 // Deal with a M585


### PR DESCRIPTION
also reports whether error was in file or macro

Tested on Duet3 Mini 5+ in standalone with following error scenarios:
- target position outside machine limits in file, macro, and console
  - Tests `GCodeBuffer::ThrowGCodeException()`
- Missing number after `G1 X` in file, macro, and console
  - Tests `StringParser::ConstructParseException()`

Unsure when `BinaryParser::ConstructParseException()` is used so not sure how to test it.

https://github.com/Duet3D/RepRapFirmware/issues/800