### PR TITLE
Suppress `M261.1` Modbus comm error when `V` passed

### DIFF
--- a/src/Platform/Platform.cpp
+++ b/src/Platform/Platform.cpp
@@ -2709,12 +2709,12 @@ GCodeResult Platform::ReceiveI2cOrModbus(GCodeBuffer& gb, const StringRef &reply
 						break;
 					}
 				}
-				else
+				else if (resultVar == nullptr) // Only report comm error if not storing result in variable
 				{
 					reply.copy("no or bad response from Modbus device");
 				}
 			}
-			else
+			else if (resultVar == nullptr)
 			{
 				reply.copy("couldn't initiate Modbus transaction");
 			}


### PR DESCRIPTION
Quick overview on the [forum](https://forum.duet3d.com/topic/36350/modbus-spindle-control) - but in short, it is already possible to check the status of the Modbus request by checking that the value of the variable is not `null`.

The error message output by `M261.1` on Modbus communication failure is unnecessary for reads where the `null` result ends up in a variable anyway, and just ends up spamming the console when using the command programmatically. 