### PR TITLE
Allow feed-rate override on G38 straight probes

### DIFF
--- a/src/GCodes/GCodes4.cpp
+++ b/src/GCodes/GCodes4.cpp
@@ -1559,7 +1559,14 @@ void GCodes::RunStateMachine(GCodeBuffer& gb, const StringRef& reply) noexcept
 						ms.checkEndstops = true;
 						ms.reduceAcceleration = true;
 						straightProbeSettings.SetCoordsToTarget(ms.coords);
-						ms.feedRate = zp->GetProbingSpeed(0);
+						if(straightProbeSettings.GetFeedRateOverride() > 0)
+						{
+							ms.feedRate = straightProbeSettings.GetFeedRateOverride();
+						}
+						else
+						{
+							ms.feedRate = zp->GetProbingSpeed(0);
+						}
 						ms.linearAxesMentioned = ms.rotationalAxesMentioned = true;
 						NewSingleSegmentMoveAvailable(ms);
 						gb.AdvanceState();

--- a/src/GCodes/GCodes6.cpp
+++ b/src/GCodes/GCodes6.cpp
@@ -659,6 +659,12 @@ GCodeResult GCodes::StraightProbe(GCodeBuffer& gb, const StringRef& reply) THROW
 	}
 	straightProbeSettings.SetZProbeToUse(probeToUse);
 
+	// Check if feed rate has been specified
+	if (gb.Seen('F'))
+	{
+		straightProbeSettings.SetFeedRateOverride(gb.GetSpeedFromMm(false));
+	}
+
 	gb.SetState(GCodeState::straightProbe0);
 	return GCodeResult::ok;
 }

--- a/src/GCodes/StraightProbeSettings.cpp
+++ b/src/GCodes/StraightProbeSettings.cpp
@@ -15,6 +15,7 @@ StraightProbeSettings::StraightProbeSettings() noexcept
 
 void StraightProbeSettings::Reset() noexcept
 {
+	feedRateOverride = 0.0;
 	movingAxes = AxesBitmap();
 	type = StraightProbeType::unset;
 	for (size_t axis = 0; axis < MaxAxes; ++axis)

--- a/src/GCodes/StraightProbeSettings.h
+++ b/src/GCodes/StraightProbeSettings.h
@@ -40,12 +40,16 @@ public:
 	const size_t GetZProbeToUse() const noexcept { return probeToUse; }
 	void SetZProbeToUse(const size_t probeNumber) noexcept { probeToUse = probeNumber; }
 
+	const float GetFeedRateOverride() const noexcept { return feedRateOverride; }
+	void SetFeedRateOverride(const float feedRate) noexcept { feedRateOverride = feedRate; }
+
 	const bool ProbingAway() const noexcept;
 	const bool SignalError() const noexcept;
 
 private:
 	AxesBitmap movingAxes;                 // Axes supposed to move - this is only used for manual probing
 	size_t probeToUse;                     // Use this ZProbe
+	float feedRateOverride;                // Feed rate for the probing move
 	float target[MaxAxes];                 // G38 target coordinates for straight probe moves
 	StraightProbeType type;                // Type of move
 };


### PR DESCRIPTION
I posted a [forum thread](https://forum.duet3d.com/topic/34980/g38-speed-selection?_=1727078279052) a while ago about this (which may have been missed), but I noticed today on reprap.org that `G38` commands already have the `F` parameter defined as a feed-rate override, but this is not currently supported by RRF.

This PR implements the `F` parameter on `G38` straight probes, allowing the default probing speed to be overridden.

Ideally we could select to use the already-defined probe speeds directly, although with this PR that could be achieved in a roundabout way, without having to modify the probe speeds or machine limits temporarily:

```
G38.3 K{var.probeId) X140 F{sensors.probes[var.probeId].speeds[0]}
G38.3 K{var.probeId} X140 F{sensors.probes[var.probeId].speeds[1]}
```
 etc.

Tested locally to confirm that this applies the speed override when specified and applies the default speed when not.