### PR TITLE
Add alternate enable config for spindle control

### DIFF
--- a/src/Platform/Platform.cpp
+++ b/src/Platform/Platform.cpp
@@ -3810,8 +3810,8 @@ GCodeResult Platform::ConfigurePort(GCodeBuffer& gb, const StringRef& reply) THR
 		}
 	case 32:	// R
 		{
-			const uint32_t slot = gb.GetLimitedUIValue('R', MaxSpindles);
-			return spindles[slot].Configure(gb, reply);
+			const uint32_t spindleNumber = gb.GetLimitedUIValue('R', MaxSpindles);
+			return spindles[spindleNumber].Configure(spindleNumber, gb, reply);
 		}
 
 #if SUPPORT_LED_STRIPS

--- a/src/Tools/Spindle.cpp
+++ b/src/Tools/Spindle.cpp
@@ -117,47 +117,47 @@ GCodeResult Spindle::Configure(uint32_t spindleNumber, GCodeBuffer& gb, const St
 	{
 		state = SpindleState::stopped;
 		reprap.SpindlesUpdated();
+		return GCodeResult::ok;
 	}
-	else if (state == SpindleState::unconfigured)
+
+	if (state == SpindleState::unconfigured)
 	{
 		reply.printf("Spindle %lu is unconfigured", spindleNumber);
 		return GCodeResult::error;
 	}
-	else
+
+	reply.catf("Spindle %lu: ", spindleNumber);
+
+	if (state == SpindleState::forward || state == SpindleState::reverse)
 	{
-		reply.catf("Spindle %lu: ", spindleNumber);
-
-		if (state == SpindleState::forward || state == SpindleState::reverse)
-		{
-			reply.catf("running %s at %lu rpm, ", state.ToString(), GetCurrentRpm());
-		}
-
-		reply.catf("type %s", type.ToString());
-
-		bool isEnaDir = type == SpindleType::standard;
-
-		if (onOffPort.IsValid())
-		{
-			reply.cat(", ");
-			reply.catf(isEnaDir ? "enable" : "forward");
-			onOffPort.AppendBasicDetails(reply);
-		}
-
-		if (reverseNotForwardPort.IsValid())
-		{
-			reply.cat(", ");
-			reply.catf(isEnaDir? "direction" : "reverse");
-			reverseNotForwardPort.AppendBasicDetails(reply);
-		}
-
-		if (pwmPort.IsValid())
-		{
-			reply.cat(", rpm");
-			pwmPort.AppendFullDetails(reply);
-		}
-
-		reply.catf(", rpm min %ld, max %ld", minRpm, maxRpm);
+		reply.catf("running %s at %lu rpm, ", state.ToString(), GetCurrentRpm());
 	}
+
+	reply.catf("type %s", type.ToString());
+
+	bool isEnaDir = type == SpindleType::standard;
+
+	if (onOffPort.IsValid())
+	{
+		reply.cat(", ");
+		reply.catf(isEnaDir ? "enable" : "forward");
+		onOffPort.AppendBasicDetails(reply);
+	}
+
+	if (reverseNotForwardPort.IsValid())
+	{
+		reply.cat(", ");
+		reply.catf(isEnaDir? "direction" : "reverse");
+		reverseNotForwardPort.AppendBasicDetails(reply);
+	}
+
+	if (pwmPort.IsValid())
+	{
+		reply.cat(", rpm");
+		pwmPort.AppendFullDetails(reply);
+	}
+
+	reply.catf(", rpm min %ld, max %ld", minRpm, maxRpm);
 	return GCodeResult::ok;
 }
 

--- a/src/Tools/Spindle.h
+++ b/src/Tools/Spindle.h
@@ -14,16 +14,19 @@
 #include <General/NamedEnum.h>
 
 NamedEnum(SpindleState, uint8_t, unconfigured, stopped, forward, reverse);
+NamedEnum(SpindleType, uint8_t, standard, fwdrev);
+
+const SpindleType DefaultSpindleType(SpindleType::standard);
 
 class Spindle INHERIT_OBJECT_MODEL
 {
 private:
 	void SetRpm(uint32_t rpm) noexcept;
-
 	PwmPort pwmPort, onOffPort, reverseNotForwardPort;
 	float minPwm, maxPwm, idlePwm;
 	uint32_t currentRpm, configuredRpm, minRpm, maxRpm;
 	PwmFrequency frequency;
+	SpindleType type;
 	SpindleState state;
 
 protected:
@@ -32,7 +35,7 @@ protected:
 public:
 	Spindle() noexcept;
 
-	GCodeResult Configure(GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeException);
+	GCodeResult Configure(uint32_t spindleNumber, GCodeBuffer& gb, const StringRef& reply) THROWS(GCodeException);
 
 	uint32_t GetCurrentRpm() const noexcept { return currentRpm; }
 	uint32_t GetMinRpm() const noexcept { return minRpm; }
@@ -40,6 +43,7 @@ public:
 	uint32_t GetRpm() const noexcept { return configuredRpm; }
 	bool IsValidRpm(uint32_t rpm) const noexcept { return rpm >= minRpm && rpm <= maxRpm; }
 	void SetConfiguredRpm(uint32_t rpm, bool updateCurrentRpm) noexcept;
+	SpindleType GetType() const noexcept { return type; }
 	SpindleState GetState() const noexcept { return state; }
 	void SetState(SpindleState newState) noexcept;
 };


### PR DESCRIPTION
Discussed here - https://forum.duet3d.com/topic/35936/direction-control-in-rrf/6?_=1730375174481 - I have been using this implementation on my own system for a couple of months and it works perfectly.

For directional spindle control, RRF currently has 2 pins - `enable` and `direction`, with the following states:

```
SpindleState::forward: enable=1, direction=0
SpindleState::reverse: enable=1, direction=1
SpindleState::stopped: enable=0, direction=? // Unknown, as RRF does not change direction pin state when stopping spindle
```

This requires connecting to a VFD that expects an `enable` pin and a `direction` pin, where it is valid for both enable and direction to be logic high at once (and that means reverse).

There are lots of VFDs which do not use this control mechanism, instead taking a `forward` and `reverse` input. If you connect RRF to one of these VFDs, (`enable` => `forward` and `direction` => `reverse`) you will likely only have forward-run capability - trying to switch to reverse run will stop the spindle because both forward and reverse inputs are high.

_However_ - if the spindle is in reverse in RRF and you then _stop_ it, there is a possibility that the VFD will start the spindle at that point - because RRF does not set the state of the direction pin when stopping the spindle.

This is obviously not ideal and means RRF cannot be used safely for reverse running with VFDs that don't match the RRF Spindle control mechanism (which isn't necessarily obvious).

I propose in this PR an alternate configuration, using the alternate pin specifier `*` on the `enable` pin. This would be given as part of the `M950` command to configure the spindle, for example:

```gcode
; Configure spindle in Normal mode
; Forward: spindleen=1, spindledir=0
; Backward: spindleen=1, spindledir=1
M950 R0 C"spindlepwm+spindleen+spindledir" L1999:24000 Q1000

; Configure spindle in Alternate mode
; Forward: spindleen=1, spindledir=0
; Backward: spindleen=0, spindledir=1
M950 R0 C"spindlepwm+*spindleen+spindledir" L1999:24000 Q1000
```

This PR implements this alternate behaviour, and also makes sure that the `direction` pin has its' value set when the spindle is stopped to avoid accidentally starting the spindle when it should be stopped.