### PR TITLE
Add J2 option on M291 - return -1 instead of abort

### DIFF
--- a/src/GCodes/GCodeBuffer/GCodeBuffer.cpp
+++ b/src/GCodes/GCodeBuffer/GCodeBuffer.cpp
@@ -1208,7 +1208,7 @@ void GCodeBuffer::MacroFileClosed() noexcept
 
 // Tell this input source that any message it sent and is waiting on has been acknowledged
 // Allow for the possibility that the source may have started running a macro since it started waiting
-void GCodeBuffer::MessageAcknowledged(bool cancelled, uint32_t seq, ExpressionValue rslt) noexcept
+void GCodeBuffer::MessageAcknowledged(bool cancelled, bool shouldAbort, uint32_t seq, ExpressionValue rslt) noexcept
 {
 	for (GCodeMachineState *_ecv_null ms = machineState; ms != nullptr; ms = ms->GetPrevious())
 	{
@@ -1216,7 +1216,7 @@ void GCodeBuffer::MessageAcknowledged(bool cancelled, uint32_t seq, ExpressionVa
 		{
 			ms->waitingForAcknowledgement = false;
 			ms->messageAcknowledged = true;
-			ms->messageCancelled = cancelled;
+			ms->messageShouldAbort = cancelled && shouldAbort;
 			m291Result = rslt;
 			if (cancelled)
 			{

--- a/src/GCodes/GCodeBuffer/GCodeBuffer.h
+++ b/src/GCodes/GCodeBuffer/GCodeBuffer.h
@@ -241,7 +241,7 @@ public:
 	void SetState(GCodeState newState) noexcept;
 	void SetState(GCodeState newState, uint16_t param) noexcept;
 	void AdvanceState() noexcept;
-	void MessageAcknowledged(bool cancelled, uint32_t seq, ExpressionValue rslt) noexcept;
+	void MessageAcknowledged(bool cancelled, bool shouldAbort, uint32_t seq, ExpressionValue rslt) noexcept;
 
 	GCodeChannel GetChannel() const noexcept { return codeChannel; }
 	bool IsFileChannel() const noexcept

--- a/src/GCodes/GCodeMachineState.h
+++ b/src/GCodes/GCodeMachineState.h
@@ -254,7 +254,7 @@ public:
 		usingInches : 1,						// true if units are inches not mm
 		waitingForAcknowledgement : 1,
 		messageAcknowledged : 1,
-		messageCancelled : 1,
+		messageShouldAbort : 1,
 		localPush : 1,							// true if this stack frame was created by M120, so we use the parent variables
 		macroRestartable : 1,					// true if the current macro has used M98 R1 to say that it can be interrupted and restarted
 		firstCommandAfterRestart : 1,			// true if this is the first command after restarting a macro that was interrupted

--- a/src/GCodes/GCodes.cpp
+++ b/src/GCodes/GCodes.cpp
@@ -478,10 +478,10 @@ bool GCodes::SpinGCodeBuffer(GCodeBuffer& gb) noexcept
 	{
 		if (gb.LatestMachineState().messageAcknowledged)
 		{
-			const bool wasCancelled = gb.LatestMachineState().messageCancelled;
+			const bool shouldAbort = gb.LatestMachineState().messageShouldAbort;
 			gb.PopState(true);											// this could fail if the current macro has already been aborted
 
-			if (wasCancelled)
+			if (shouldAbort)
 			{
 				if (gb.LatestMachineState().GetPrevious() == nullptr)
 				{
@@ -498,7 +498,7 @@ bool GCodes::SpinGCodeBuffer(GCodeBuffer& gb) noexcept
 					FileMacroCyclesReturn(gb);
 				}
 			}
-			result = wasCancelled;
+			result = shouldAbort;
 		}
 		else
 		{

--- a/src/GCodes/GCodes.h
+++ b/src/GCodes/GCodes.h
@@ -272,7 +272,7 @@ public:
 	const MovementState& GetCurrentMovementState(const ObjectExplorationContext& context) const noexcept;
 	const MovementState& GetConstMovementState(const GCodeBuffer& gb) const noexcept;			// Get a reference to the movement state associated with the specified GCode buffer (there is a private non-const version)
 	bool IsHeaterUsedByDifferentCurrentTool(int heaterNumber, const Tool *tool) const noexcept;	// Check if the specified heater is used by a current tool other than the specified one
-	void MessageBoxClosed(bool cancelled, bool m292, uint32_t seq, ExpressionValue rslt) noexcept;
+	void MessageBoxClosed(bool cancelled, bool shouldAbort, bool m292, uint32_t seq, ExpressionValue rslt) noexcept;
 
 # if HAS_VOLTAGE_MONITOR
 	const char *_ecv_array null GetPowerFailScript() const noexcept { return powerFailScript; }

--- a/src/GCodes/GCodes7.cpp
+++ b/src/GCodes/GCodes7.cpp
@@ -32,7 +32,12 @@ GCodeResult GCodes::DoMessageBox(GCodeBuffer&gb, const StringRef& reply) THROWS(
 	gb.TryGetNonNegativeFValue('T', tParam, dummy);
 
 	MessageBoxLimits limits;
-	gb.TryGetBValue('J', limits.canCancel, dummy);
+	uint32_t jParam = 0;
+	if(gb.TryGetLimitedUIValue('J', jParam, dummy, 3))
+	{
+		limits.canCancel = jParam > 0;
+		limits.shouldAbort = jParam < 2;
+	}
 
 	AxesBitmap axisControls;
 
@@ -129,11 +134,12 @@ GCodeResult GCodes::AcknowledgeMessage(GCodeBuffer&gb, const StringRef& reply) T
 	}
 
 	bool wasBlocking;
-	if (MessageBox::Acknowledge(seq, wasBlocking))
+	bool shouldAbort;
+	if (MessageBox::Acknowledge(seq, wasBlocking, shouldAbort))
 	{
 		if (wasBlocking)
 		{
-			MessageBoxClosed(cancelled, true, seq, rslt);
+			MessageBoxClosed(cancelled, shouldAbort, true, seq, rslt);
 		}
 	}
 	else
@@ -142,21 +148,25 @@ GCodeResult GCodes::AcknowledgeMessage(GCodeBuffer&gb, const StringRef& reply) T
 		// so that when it is executed the message box has already timed out (issue 730). So don't report an error in this case.
 		// Do nothing
 	}
-	return GCodeResult::ok;
+
+	// Return -1 if cancelled. If shouldAbort is true, then the containing macro will be aborted before
+	// this value can be read - but for consistency, we return 0.
+	return (cancelled && !shouldAbort) ? GCodeResult::m291Cancelled : GCodeResult::ok;
 }
 
 // Deal with processing a M292 or timing out a message box
-void GCodes::MessageBoxClosed(bool cancelled, bool m292, uint32_t seq, ExpressionValue rslt) noexcept
+void GCodes::MessageBoxClosed(bool cancelled, bool shouldAbort, bool m292, uint32_t seq, ExpressionValue rslt) noexcept
 {
 	platform.MessageF(MessageType::LogInfo,
-						"%s: cancelled=%s",
+						"%s: cancelled=%s shouldAbort=%s",
 							(m292) ? "M292" : "Message box timed out",
-								(cancelled ? "true" : "false"));
+								(cancelled ? "true" : "false"),
+									(shouldAbort ? "true" : "false"));
 	for (GCodeBuffer *_ecv_null targetGb : gcodeSources)
 	{
 		if (targetGb != nullptr)
 		{
-			targetGb->MessageAcknowledged(cancelled, seq, rslt);
+			targetGb->MessageAcknowledged(cancelled, shouldAbort, seq, rslt);
 		}
 	}
 }

--- a/src/Platform/MessageBox.h
+++ b/src/Platform/MessageBox.h
@@ -21,6 +21,7 @@ struct MessageBoxLimits
 
 	ExpressionValue minVal, maxVal, defaultVal, choices;
 	bool canCancel = false;
+	bool shouldAbort = true;
 };
 
 // Message box data
@@ -34,7 +35,7 @@ public:
 	static bool HaveCurrent() noexcept { return mboxList != nullptr; }
 	static MessageBox *_ecv_null GetCurrent() noexcept { return mboxList; }
 	static ReadLockedPointer<const MessageBox> GetLockedCurrent() noexcept;
-	static bool Acknowledge(uint32_t ackSeq, bool& wasBlocking) noexcept;
+	static bool Acknowledge(uint32_t ackSeq, bool& wasBlocking, bool& shouldAbort) noexcept;
 	static bool CheckTimeout() noexcept;
 
 	// Return true if the mode of this message box is one that the legacy status calls can handle
@@ -54,6 +55,7 @@ public:
 	const char *_ecv_array GetTitle() const noexcept { return title.c_str(); }
 	ExpressionValue GetDefaultValue() const noexcept { return limits.defaultVal; }
 	bool CanCancel() const noexcept { return limits.canCancel; }
+	bool ShouldAbort() const noexcept { return limits.shouldAbort; }
 
 	static ReadWriteLock mboxLock;
 

--- a/src/SBC/SbcInterface.cpp
+++ b/src/SBC/SbcInterface.cpp
@@ -1336,7 +1336,7 @@ void SbcInterface::InvalidateResources() noexcept
 		}
 		gb->AbortFile(true);
 		gb->FileAbortSent();	// don't notify the SBC
-		gb->MessageAcknowledged(true, 0, ExpressionValue());
+		gb->MessageAcknowledged(true, true, 0, ExpressionValue());
 	}
 
 	// Abort the print (if applicable)


### PR DESCRIPTION
Forum discussion [here](https://forum.duet3d.com/topic/34945/meta-gcode-result-variable-inconsistent-with-docs/6?_=1730826472074), feature request #959 - this PR implements the discussed `J2` argument to `M291` which changes the behaviour of message boxes that have a cancel button.

With `J0` or `J1` the existing message box behaviour is unchanged, either not allowing the message box to be cancelled, or allowing it to be cancelled but in a manner that will return out of the macro that called `M291` or stopping the print (if called directly from a print file).

With `J2` set, this behaviour is changed to instead return `-1` in the `result` variable from the `M291` call - so that recovery from the user clicking the cancel button can be performed after the `M291` call.

Below screenshot shows the changed behaviour with `J2`.

![m291-j2](https://github.com/user-attachments/assets/382aacb9-cb71-4489-b2f2-889a5d0aa801)

Caveat: If the message box times out with `J2`, then this will still be indistinguishable from the user clicking `Cancel`, just like with `J1`. 


